### PR TITLE
feat: be more specific about encoding config

### DIFF
--- a/packages/encodable/src/types/Encoding.ts
+++ b/packages/encodable/src/types/Encoding.ts
@@ -1,5 +1,4 @@
 import { ChannelTypeToDefMap } from './Channel';
-import { Value } from './VegaLite';
 import ChannelEncoder from '../encoders/ChannelEncoder';
 
 /**
@@ -9,7 +8,7 @@ export type EncodingConfig = {
   [k in string]:
     | ['X' | 'Y' | 'XBand' | 'YBand' | 'Numeric', number | null, 'multiple'?]
     | ['Color' | 'Text', string | null, 'multiple'?]
-    | ['Category', Value, 'multiple'?];
+    | ['Category', string | boolean | null, 'multiple'?];
 };
 
 export type DeriveChannelTypes<Config extends EncodingConfig> = {

--- a/packages/encodable/src/types/Encoding.ts
+++ b/packages/encodable/src/types/Encoding.ts
@@ -1,9 +1,15 @@
-import { ChannelType, ChannelTypeToDefMap } from './Channel';
+import { ChannelTypeToDefMap } from './Channel';
 import { Value } from './VegaLite';
 import ChannelEncoder from '../encoders/ChannelEncoder';
 
+/**
+ * { [channelName]: [ChannelType, Output, multiple?] }
+ */
 export type EncodingConfig = {
-  [k in string]: [ChannelType, Value, 'multiple'?];
+  [k in string]:
+    | ['X' | 'Y' | 'XBand' | 'YBand' | 'Numeric', number | null, 'multiple'?]
+    | ['Color' | 'Text', string | null, 'multiple'?]
+    | ['Category', Value, 'multiple'?];
 };
 
 export type DeriveChannelTypes<Config extends EncodingConfig> = {


### PR DESCRIPTION
🏆 Enhancements

| ChannelType | Example channel | Output types |
|----|----|----|
| `X` |  bubble chart's x-position | `number \| null` |
| `Y` |  bubble chart's y-position | `number \| null` |
| `XBand` | vertical bar chart's x-position | `number \| null` |
| `YBand` |  horizontal bar chart's y-position | `number \| null` |
| `Numeric` |  bubble chart's bubble size | `number \| null` |
| `Color` |  bubble chart's bubble color | `string \| null` |
| `Text` |  bubble chart's bubble label | `string \| null` |
| `Category` |  bubble chart's fill or not (`boolean`), pattern (`string`) | `string \| boolean \| null` |

