### PR TITLE
build: bump build-config, vega-lite dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
-    "@superset-ui/build-config": "^0.1.3",
+    "@superset-ui/build-config": "^0.2.0",
     "@superset-ui/commit-config": "^0.0.9",
     "fast-glob": "^3.0.1",
     "fs-extra": "^8.0.1",

--- a/packages/encodable/package.json
+++ b/packages/encodable/package.json
@@ -44,15 +44,12 @@
     "d3-time": "^1.0.11",
     "lodash": "^4.17.15",
     "reselect": "^4.0.0",
-    "vega": "5.6.0",
+    "vega": "^5.8.1",
     "vega-expression": "^2.6.2",
-    "vega-lite": "3.4.0"
+    "vega-lite": "^4.0.0-beta.12"
   },
   "devDependencies": {
-    "@superset-ui/color": "^0.12.0",
-    "@superset-ui/core": "^0.12.4",
-    "@superset-ui/number-format": "^0.12.0",
-    "@superset-ui/time-format": "^0.12.0"
+    "@superset-ui/superset-ui": "^0.12.5"
   },
   "peerDependencies": {
     "@superset-ui/color": "^0.12.0",


### PR DESCRIPTION
🏠 Internal
* Use latest `vega` and `vega-lite`
* Build using `typescript@3.7`