### PR TITLE
feat: add functions and typeguards for checking definition types

### DIFF
--- a/packages/encodable/src/encoders/ChannelEncoder.ts
+++ b/packages/encodable/src/encoders/ChannelEncoder.ts
@@ -4,7 +4,7 @@ import { ChannelType, ChannelInput } from '../types/Channel';
 import { PlainObject, Dataset } from '../types/Data';
 import { ChannelDef } from '../types/ChannelDef';
 import { Value } from '../types/VegaLite';
-import { isTypedFieldDef, isValueDef } from '../typeGuards/ChannelDef';
+import { isTypedFieldDef, isValueDef, isFieldDef } from '../typeGuards/ChannelDef';
 import { isX, isY, isXOrY } from '../typeGuards/Channel';
 import ChannelEncoderAxis from './ChannelEncoderAxis';
 import createGetterFromChannelDef, { Getter } from '../parsers/createGetterFromChannelDef';
@@ -58,10 +58,9 @@ export default class ChannelEncoder<Def extends ChannelDef<Output>, Output exten
       this.encodeFunc = (value: ChannelInput) => scale(value) as Output;
       this.scale = scale;
     } else {
-      this.encodeFunc =
-        'value' in this.definition
-          ? () => (this.definition as CompleteValueDef<Output>).value
-          : identity;
+      this.encodeFunc = this.hasValueDefinition()
+        ? () => (this.definition as CompleteValueDef<Output>).value
+        : identity;
     }
 
     if (this.definition.axis) {
@@ -135,7 +134,9 @@ export default class ChannelEncoder<Def extends ChannelDef<Output>, Output exten
   }
 
   setDomainFromDataset(data: Dataset) {
-    return this.scale ? this.setDomain(this.getDomainFromDataset(data)) : this;
+    return this.scale && 'domain' in this.scale
+      ? this.setDomain(this.getDomainFromDataset(data))
+      : this;
   }
 
   getTitle() {
@@ -171,5 +172,13 @@ export default class ChannelEncoder<Def extends ChannelDef<Output>, Output exten
 
   hasLegend() {
     return this.definition.legend !== false;
+  }
+
+  hasValueDefinition() {
+    return isValueDef(this.definition);
+  }
+
+  hasFieldDefinition() {
+    return isFieldDef(this.definition);
   }
 }

--- a/packages/encodable/src/encoders/ChannelEncoder.ts
+++ b/packages/encodable/src/encoders/ChannelEncoder.ts
@@ -4,14 +4,11 @@ import { ChannelType, ChannelInput } from '../types/Channel';
 import { PlainObject, Dataset } from '../types/Data';
 import { ChannelDef } from '../types/ChannelDef';
 import { Value } from '../types/VegaLite';
-import { isTypedFieldDef, isValueDef, isFieldDef } from '../typeGuards/ChannelDef';
+import { isTypedFieldDef, isValueDef } from '../typeGuards/ChannelDef';
 import { isX, isY, isXOrY } from '../typeGuards/Channel';
 import ChannelEncoderAxis from './ChannelEncoderAxis';
 import createGetterFromChannelDef, { Getter } from '../parsers/createGetterFromChannelDef';
-import completeChannelDef, {
-  CompleteChannelDef,
-  CompleteValueDef,
-} from '../fillers/completeChannelDef';
+import completeChannelDef from '../fillers/completeChannelDef';
 import createFormatterFromChannelDef from '../parsers/format/createFormatterFromChannelDef';
 import createScaleFromScaleConfig from '../parsers/scale/createScaleFromScaleConfig';
 import identity from '../utils/identity';
@@ -19,6 +16,8 @@ import applyDomain from '../parsers/scale/applyDomain';
 import applyZero from '../parsers/scale/applyZero';
 import applyNice from '../parsers/scale/applyNice';
 import { AllScale } from '../types/Scale';
+import { isCompleteValueDef, isCompleteFieldDef } from '../typeGuards/CompleteChannelDef';
+import { CompleteChannelDef } from '../types/CompleteChannelDef';
 
 type EncodeFunction<Output> = (value: ChannelInput) => Output | null | undefined;
 
@@ -58,9 +57,8 @@ export default class ChannelEncoder<Def extends ChannelDef<Output>, Output exten
       this.encodeFunc = (value: ChannelInput) => scale(value) as Output;
       this.scale = scale;
     } else {
-      this.encodeFunc = this.hasValueDefinition()
-        ? () => (this.definition as CompleteValueDef<Output>).value
-        : identity;
+      const { definition } = this;
+      this.encodeFunc = isCompleteValueDef(definition) ? () => definition.value : identity;
     }
 
     if (this.definition.axis) {
@@ -175,10 +173,10 @@ export default class ChannelEncoder<Def extends ChannelDef<Output>, Output exten
   }
 
   hasValueDefinition() {
-    return isValueDef(this.definition);
+    return isCompleteValueDef(this.definition);
   }
 
   hasFieldDefinition() {
-    return isFieldDef(this.definition);
+    return isCompleteFieldDef(this.definition);
   }
 }

--- a/packages/encodable/src/encoders/ChannelEncoderAxis.ts
+++ b/packages/encodable/src/encoders/ChannelEncoderAxis.ts
@@ -3,7 +3,7 @@ import createFormatterFromFieldTypeAndFormat from '../parsers/format/createForma
 import { CompleteAxisConfig } from '../fillers/completeAxisConfig';
 import { ChannelDef } from '../types/ChannelDef';
 import { Value, isDateTime } from '../types/VegaLite';
-import { CompleteFieldDef } from '../fillers/completeChannelDef';
+import { CompleteFieldDef } from '../types/CompleteChannelDef';
 import { ChannelInput } from '../types/Channel';
 import { HasToString } from '../types/Base';
 import parseDateTime from '../parsers/parseDateTime';

--- a/packages/encodable/src/fillers/completeChannelDef.ts
+++ b/packages/encodable/src/fillers/completeChannelDef.ts
@@ -1,33 +1,12 @@
-import { ChannelDef, NonValueDef } from '../types/ChannelDef';
+import { ChannelDef } from '../types/ChannelDef';
 import { ChannelType } from '../types/Channel';
 import { isFieldDef, isValueDef, isTypedFieldDef } from '../typeGuards/ChannelDef';
-import completeAxisConfig, { CompleteAxisConfig } from './completeAxisConfig';
-import completeLegendConfig, { CompleteLegendConfig } from './completeLegendConfig';
-import completeScaleConfig, { CompleteScaleConfig } from './completeScaleConfig';
-import { Value, ValueDef, Type } from '../types/VegaLite';
+import completeAxisConfig from './completeAxisConfig';
+import completeLegendConfig from './completeLegendConfig';
+import completeScaleConfig from './completeScaleConfig';
+import { Value } from '../types/VegaLite';
 import inferFieldType from './inferFieldType';
-
-export interface CompleteValueDef<Output extends Value = Value> extends ValueDef<Output> {
-  axis: false;
-  legend: false;
-  scale: false;
-  title: '';
-}
-
-export type CompleteFieldDef<Output extends Value = Value> = Omit<
-  NonValueDef<Output>,
-  'title' | 'axis' | 'scale'
-> & {
-  type: Type;
-  axis: CompleteAxisConfig;
-  legend: CompleteLegendConfig;
-  scale: CompleteScaleConfig<Output>;
-  title: string;
-};
-
-export type CompleteChannelDef<Output extends Value = Value> =
-  | CompleteValueDef<Output>
-  | CompleteFieldDef<Output>;
+import { CompleteChannelDef } from '../types/CompleteChannelDef';
 
 export default function completeChannelDef<Output extends Value>(
   channelType: ChannelType,

--- a/packages/encodable/src/fillers/completeLegendConfig.ts
+++ b/packages/encodable/src/fillers/completeLegendConfig.ts
@@ -14,5 +14,5 @@ export default function completeLegendConfig<Output extends Value = Value>(
     return channelDef.legend;
   }
 
-  return isXOrY(channelType) ? false : {};
+  return isXOrY(channelType) || channelType === 'Text' ? false : {};
 }

--- a/packages/encodable/src/typeGuards/CompleteChannelDef.ts
+++ b/packages/encodable/src/typeGuards/CompleteChannelDef.ts
@@ -1,0 +1,18 @@
+import {
+  CompleteChannelDef,
+  CompleteValueDef,
+  CompleteFieldDef,
+} from '../types/CompleteChannelDef';
+import { Value } from '../types/VegaLite';
+
+export function isCompleteValueDef<Output extends Value = Value>(
+  def: CompleteChannelDef<Output>,
+): def is CompleteValueDef<Output> {
+  return 'value' in def;
+}
+
+export function isCompleteFieldDef<Output extends Value = Value>(
+  def: CompleteChannelDef<Output>,
+): def is CompleteFieldDef<Output> {
+  return 'field' in def;
+}

--- a/packages/encodable/src/types/CompleteChannelDef.ts
+++ b/packages/encodable/src/types/CompleteChannelDef.ts
@@ -1,0 +1,27 @@
+import { Value, ValueDef, Type } from './VegaLite';
+import { CompleteAxisConfig } from '../fillers/completeAxisConfig';
+import { CompleteLegendConfig } from '../fillers/completeLegendConfig';
+import { CompleteScaleConfig } from '../fillers/completeScaleConfig';
+import { NonValueDef } from './ChannelDef';
+
+export interface CompleteValueDef<Output extends Value = Value> extends ValueDef<Output> {
+  axis: false;
+  legend: false;
+  scale: false;
+  title: '';
+}
+
+export type CompleteFieldDef<Output extends Value = Value> = Omit<
+  NonValueDef<Output>,
+  'title' | 'axis' | 'scale'
+> & {
+  type: Type;
+  axis: CompleteAxisConfig;
+  legend: CompleteLegendConfig;
+  scale: CompleteScaleConfig<Output>;
+  title: string;
+};
+
+export type CompleteChannelDef<Output extends Value = Value> =
+  | CompleteValueDef<Output>
+  | CompleteFieldDef<Output>;

--- a/packages/encodable/test/encoders/ChannelEncoder.test.ts
+++ b/packages/encodable/test/encoders/ChannelEncoder.test.ts
@@ -519,4 +519,52 @@ describe('ChannelEncoder', () => {
       expect(encoder.hasLegend()).toBeFalsy();
     });
   });
+
+  describe('.hasValueDefinition()', () => {
+    it('returns true if definition is ValueDef', () => {
+      const encoder = new ChannelEncoder({
+        name: 'x',
+        channelType: 'X',
+        definition: {
+          value: 1,
+        },
+      });
+      expect(encoder.hasValueDefinition()).toBeTruthy();
+    });
+    it('returns false otherwise', () => {
+      const encoder = new ChannelEncoder({
+        name: 'x',
+        channelType: 'X',
+        definition: {
+          type: 'quantitative',
+          field: 'speed',
+        },
+      });
+      expect(encoder.hasValueDefinition()).toBeFalsy();
+    });
+  });
+
+  describe('hasFieldDefinition()', () => {
+    it('returns true if definition is FieldDef', () => {
+      const encoder = new ChannelEncoder({
+        name: 'x',
+        channelType: 'X',
+        definition: {
+          type: 'quantitative',
+          field: 'speed',
+        },
+      });
+      expect(encoder.hasFieldDefinition()).toBeTruthy();
+    });
+    it('returns false otherwise', () => {
+      const encoder = new ChannelEncoder({
+        name: 'x',
+        channelType: 'X',
+        definition: {
+          value: 1,
+        },
+      });
+      expect(encoder.hasFieldDefinition()).toBeFalsy();
+    });
+  });
 });

--- a/packages/encodable/test/fillers/completeLegendConfig.test.ts
+++ b/packages/encodable/test/fillers/completeLegendConfig.test.ts
@@ -10,21 +10,37 @@ describe('completeLegendConfig()', () => {
       }),
     ).toEqual({ a: 1 });
   });
-  it('returns default legend config if legend is undefined', () => {
-    expect(
-      completeLegendConfig('X', {
-        type: 'quantitative',
-        field: 'consumption',
-      }),
-    ).toEqual(false);
-  });
-  it('returns default legend config if legend is undefined and channel is not X or Y', () => {
-    expect(
-      completeLegendConfig('Color', {
-        type: 'nominal',
-        field: 'brand',
-      }),
-    ).toEqual({});
+  describe('if legend is undefined', () => {
+    it('returns false if channel is X or Y', () => {
+      expect(
+        completeLegendConfig('X', {
+          type: 'quantitative',
+          field: 'consumption',
+        }),
+      ).toEqual(false);
+      expect(
+        completeLegendConfig('Y', {
+          type: 'quantitative',
+          field: 'consumption',
+        }),
+      ).toEqual(false);
+    });
+    it('returns false if channel is Text', () => {
+      expect(
+        completeLegendConfig('Text', {
+          type: 'nominal',
+          field: 'name',
+        }),
+      ).toEqual(false);
+    });
+    it('returns default legend config for remaining channel types', () => {
+      expect(
+        completeLegendConfig('Color', {
+          type: 'nominal',
+          field: 'brand',
+        }),
+      ).toEqual({});
+    });
   });
   it('returns false if legend is false', () => {
     expect(

--- a/packages/encodable/test/typeGuards/CompleteChannelDef.test.ts
+++ b/packages/encodable/test/typeGuards/CompleteChannelDef.test.ts
@@ -1,0 +1,37 @@
+import { isCompleteValueDef, isCompleteFieldDef } from '../../src/typeGuards/CompleteChannelDef';
+import { CompleteChannelDef } from '../../src/types/CompleteChannelDef';
+
+describe('type guards: ChannelDef', () => {
+  const valueDef: CompleteChannelDef = {
+    value: 'red',
+    title: '',
+    axis: false,
+    legend: false,
+    scale: false,
+  };
+  const fieldDef: CompleteChannelDef = {
+    type: 'quantitative',
+    field: 'horsepower',
+    title: 'horsepower',
+    axis: false,
+    legend: false,
+    scale: false,
+  };
+
+  describe('isCompleteValueDef(def)', () => {
+    it('returns true if is CompleteValueDef', () => {
+      expect(isCompleteValueDef(valueDef)).toBeTruthy();
+    });
+    it('return false otherwise', () => {
+      expect(isCompleteValueDef(fieldDef)).toBeFalsy();
+    });
+  });
+  describe('isCompleteFieldDef(def)', () => {
+    it('returns true if is CompleteFieldDef', () => {
+      expect(isCompleteFieldDef(fieldDef)).toBeTruthy();
+    });
+    it('return false otherwise', () => {
+      expect(isCompleteFieldDef(valueDef)).toBeFalsy();
+    });
+  });
+});


### PR DESCRIPTION
🏆 Enhancements

* Add typeguards to distinguish between `CompleteValueDef` and `CompleteFieldDef` from `CompleteChannelDef`.
* Add `.hasValueDefinition()` and `.hasFieldDefinition()` to `ChannelEncoder`

🐛 Bug fixes

* Disable legends for `Text` channel by default.