### PR TITLE
feat: encoder can set domain of all scales from dataset at once

### DIFF
--- a/packages/encodable/src/encoders/ChannelEncoder.ts
+++ b/packages/encodable/src/encoders/ChannelEncoder.ts
@@ -120,6 +120,14 @@ export default class ChannelEncoder<Def extends ChannelDef<Output>, Output exten
     return [];
   };
 
+  getDomain() {
+    if (this.scale && 'domain' in this.scale) {
+      return this.scale.domain();
+    }
+
+    return [];
+  }
+
   setDomain(domain: ChannelInput[]) {
     if (this.definition.scale !== false && this.scale && 'domain' in this.scale) {
       const config = this.definition.scale;

--- a/packages/encodable/src/encoders/Encoder.ts
+++ b/packages/encodable/src/encoders/Encoder.ts
@@ -83,11 +83,11 @@ export default class Encoder<Config extends EncodingConfig> {
   }
 
   getChannelEncoders() {
-    return this.getChannelNames().map(name => this.channels[name]);
+    return flatMap(this.getChannelNames().map(name => this.channels[name]));
   }
 
   getGroupBys() {
-    const fields = flatMap(this.getChannelEncoders())
+    const fields = this.getChannelEncoders()
       .filter(c => c.isGroupBy())
       .map(c => (c.definition as TypedFieldDef).field!);
 
@@ -143,6 +143,14 @@ export default class Encoder<Config extends EncodingConfig> {
           };
         })
     );
+  }
+
+  setDomainFromDataset(data: Dataset) {
+    this.getChannelEncoders().forEach(channelEncoder => {
+      channelEncoder.setDomainFromDataset(data);
+    });
+
+    return this;
   }
 
   hasLegend() {

--- a/packages/encodable/test/encoders/ChannelEncoder.test.ts
+++ b/packages/encodable/test/encoders/ChannelEncoder.test.ts
@@ -232,6 +232,43 @@ describe('ChannelEncoder', () => {
     });
   });
 
+  describe('.getDomain()', () => {
+    it('returns domain if there is scale (except CategoricalColorScale)', () => {
+      const encoder = new ChannelEncoder({
+        name: 'x',
+        channelType: 'X',
+        definition: {
+          type: 'quantitative',
+          field: 'speed',
+          scale: { domain: [0, 10] },
+        },
+      });
+      expect(encoder.getDomain()).toEqual([0, 10]);
+    });
+    it('returns empty array for CategoricalColorScale', () => {
+      const encoder = new ChannelEncoder({
+        name: 'color',
+        channelType: 'Color',
+        definition: {
+          type: 'nominal',
+          field: 'brand',
+          scale: { domain: ['pocky', 'hanami'] },
+        },
+      });
+      expect(encoder.getDomain()).toEqual([]);
+    });
+    it('returns empty array for value definition', () => {
+      const encoder = new ChannelEncoder({
+        name: 'x',
+        channelType: 'X',
+        definition: {
+          value: 1,
+        },
+      });
+      expect(encoder.getDomain()).toEqual([]);
+    });
+  });
+
   describe('.setDomain()', () => {
     it('sets the domain', () => {
       const encoder = new ChannelEncoder({

--- a/packages/encodable/test/encoders/Encoder.test.ts
+++ b/packages/encodable/test/encoders/Encoder.test.ts
@@ -49,7 +49,7 @@ describe('Encoder', () => {
   });
   describe('.getChannelEncoders()', () => {
     it('returns an array of channel encoders', () => {
-      expect(encoder.getChannelEncoders()).toHaveLength(6);
+      expect(encoder.getChannelEncoders()).toHaveLength(7);
     });
   });
   describe('.getGroupBys()', () => {
@@ -193,6 +193,22 @@ describe('Encoder', () => {
         .getLegendInformation([{ brand: 'Gucci' }, { brand: 'Prada' }]);
 
       expect(stripFunction(legendInfo)).toEqual([]);
+    });
+  });
+  describe('.setDomainFromDataset', () => {
+    it('set domain for every channels', () => {
+      const enc = factory.create({
+        shape: { type: 'ordinal', field: 'brand', scale: { range: ['circle', 'diamond'] } },
+      });
+      enc.setDomainFromDataset([
+        { speed: 1, price: 2, brand: 'Nintendo', model: 'Switch' },
+        { speed: 2, price: 4, brand: 'Playstation', model: 'PS4' },
+      ]);
+
+      expect(enc.channels.x.getDomain()).toEqual([0, 2]);
+      expect(enc.channels.y.getDomain()).toEqual([0, 4]);
+      expect(enc.channels.color.getDomain()).toEqual([]);
+      expect(enc.channels.shape.getDomain()).toEqual(['Nintendo', 'Playstation']);
     });
   });
   describe('.hasLegend()', () => {


### PR DESCRIPTION
🏆 Enhancements

* add `.setDomainFromDataset()` to `Encoder`
* add `.getDomain()` to `ChannelEncoder`