### PR TITLE
fix: namespace issue

### DIFF
--- a/packages/encodable/src/types/Base.ts
+++ b/packages/encodable/src/types/Base.ts
@@ -17,3 +17,6 @@ export type RequiredSome<T, RequiredFields extends keyof T> = {
 
 /** Signature of an identity function */
 export type IdentityFunction<T> = (value: T) => T;
+
+/** Union types of all values from a map type */
+export type ValueOf<T> = T[keyof T];

--- a/packages/encodable/src/types/VegaLite.ts
+++ b/packages/encodable/src/types/VegaLite.ts
@@ -1,7 +1,36 @@
-// Types imported from vega-lite
+import { ValueOf } from './Base';
 
+// Types imported from vega-lite
 export { ValueDef, Value } from 'vega-lite/build/src/channeldef';
 export { isDateTime, DateTime } from 'vega-lite/build/src/datetime';
-export { SchemeParams, ScaleType, Scale, NiceTime } from 'vega-lite/build/src/scale';
+export { SchemeParams, Scale, NiceTime } from 'vega-lite/build/src/scale';
 export { Axis } from 'vega-lite/build/src/axis';
 export { Type } from 'vega-lite/build/src/type';
+
+// Override this implementation
+// because vega-lite uses namespace which has issues with babel and typescript
+export const ScaleType = {
+  // Continuous - Quantitative
+  LINEAR: 'linear',
+  LOG: 'log',
+  POW: 'pow',
+  SQRT: 'sqrt',
+  SYMLOG: 'symlog',
+
+  // Continuous - Time
+  TIME: 'time',
+  UTC: 'utc',
+
+  // Discretizing scales
+  QUANTILE: 'quantile',
+  QUANTIZE: 'quantize',
+  THRESHOLD: 'threshold',
+  BIN_ORDINAL: 'bin-ordinal',
+
+  // Discrete scales
+  ORDINAL: 'ordinal',
+  POINT: 'point',
+  BAND: 'band',
+} as const;
+
+export type ScaleType = ValueOf<typeof ScaleType>;


### PR DESCRIPTION
🐛 Bug Fix

`vega-lite` use `namespace` for `ScaleType` implementation, which causes problem with `babel` when transpiling typescript. 

This PR overrides the implementation of `ScaleType` to remove the use of `namespace`.