### PR TITLE
feat: do not nice time scale by default

### DIFF
--- a/packages/encodable/src/fillers/completeScaleConfig.ts
+++ b/packages/encodable/src/fillers/completeScaleConfig.ts
@@ -6,6 +6,7 @@ import { ChannelDef } from '../types/ChannelDef';
 import isEnabled from '../utils/isEnabled';
 import { ChannelType } from '../types/Channel';
 import { Value } from '../types/VegaLite';
+import { timeScaleTypesSet } from '../parsers/scale/scaleCategories';
 
 export type CompleteScaleConfig<Output extends Value = Value> = false | ScaleConfig<Output>;
 
@@ -25,7 +26,7 @@ export default function completeScaleConfig<Output extends Value>(
     const filledScale = { ...scale, type: scaleType } as ScaleConfig<Output>;
     if (isContinuousScaleConfig(filledScale)) {
       if (typeof filledScale.nice === 'undefined') {
-        filledScale.nice = true;
+        filledScale.nice = !timeScaleTypesSet.has(scaleType);
       }
       if (typeof filledScale.clamp === 'undefined') {
         filledScale.clamp = true;

--- a/packages/encodable/test/parsers/scale/createScaleFromScaleConfig.test.ts
+++ b/packages/encodable/test/parsers/scale/createScaleFromScaleConfig.test.ts
@@ -243,7 +243,7 @@ describe('createScaleFromScaleConfig(config)', () => {
   });
 
   describe('time scale', () => {
-    it('basic', () => {
+    it('basic - does not nice by default', () => {
       const scale = createScaleFromScaleConfig({
         type: 'time',
         domain: [
@@ -255,10 +255,36 @@ describe('createScaleFromScaleConfig(config)', () => {
           {
             year: 2019,
             month: 7,
-            date: 31,
+            date: 30,
           },
         ],
         range: [0, 100],
+      });
+      expect(scale(new Date(2019, 6, 1))).toEqual(0);
+      expect(
+        scale(new Date(2019, 6, 16))
+          ?.toString()
+          .slice(0, 6),
+      ).toEqual('51.724');
+      expect(scale(new Date(2019, 6, 30))).toEqual(100);
+    });
+    it('with nice=true', () => {
+      const scale = createScaleFromScaleConfig({
+        type: 'time',
+        domain: [
+          {
+            year: 2019,
+            month: 7,
+            date: 1,
+          },
+          {
+            year: 2019,
+            month: 7,
+            date: 30,
+          },
+        ],
+        range: [0, 100],
+        nice: true,
       });
       expect(scale(new Date(2019, 6, 1))).toEqual(0);
       expect(scale(new Date(2019, 6, 16))).toEqual(50);


### PR DESCRIPTION
🏆 Enhancements

* Be more considerate and only nice non-temporal scales by default. This is due to many time series line chart has time scale as x axis. If `nice` is applied, it may create gap surrounding the lines. (gap between left edge and line, gap between right edge and line), which are less desirable than the not `nice` settings.