### PR TITLE
feat: add overloading for createScaleFromScaleConfig

### DIFF
--- a/packages/encodable/package.json
+++ b/packages/encodable/package.json
@@ -48,11 +48,11 @@
     "vega-lite": "~4.1.0"
   },
   "devDependencies": {
-    "@superset-ui/superset-ui": "^0.12.5"
+    "@superset-ui/superset-ui": "^0.12.15"
   },
   "peerDependencies": {
-    "@superset-ui/color": "^0.12.0",
-    "@superset-ui/number-format": "^0.12.0",
-    "@superset-ui/time-format": "^0.12.0"
+    "@superset-ui/color": "^0.12.15",
+    "@superset-ui/number-format": "^0.12.15",
+    "@superset-ui/time-format": "^0.12.15"
   }
 }

--- a/packages/encodable/src/encoders/ChannelEncoder.ts
+++ b/packages/encodable/src/encoders/ChannelEncoder.ts
@@ -18,6 +18,7 @@ import applyNice from '../parsers/scale/applyNice';
 import { AllScale } from '../types/Scale';
 import { isCompleteValueDef, isCompleteFieldDef } from '../typeGuards/CompleteChannelDef';
 import { CompleteChannelDef } from '../types/CompleteChannelDef';
+import { isCategoricalColorScale } from '../typeGuards/Scale';
 
 type EncodeFunction<Output> = (value: ChannelInput) => Output | null | undefined;
 
@@ -60,7 +61,7 @@ export default class ChannelEncoder<Def extends ChannelDef<Output>, Output exten
 
     if (this.definition.scale) {
       const scale = createScaleFromScaleConfig(this.definition.scale);
-      this.encodeFunc = (value: ChannelInput) => scale(value) as Output;
+      this.encodeFunc = (value: ChannelInput) => scale(value as any) as Output;
       this.scale = scale;
     } else {
       const { definition } = this;
@@ -140,7 +141,12 @@ export default class ChannelEncoder<Def extends ChannelDef<Output>, Output exten
   }
 
   setDomain(domain: ChannelInput[]) {
-    if (this.definition.scale !== false && this.scale && 'domain' in this.scale) {
+    if (
+      this.definition.scale !== false &&
+      this.scale &&
+      !isCategoricalColorScale(this.scale) &&
+      'domain' in this.scale
+    ) {
       const config = this.definition.scale;
       applyDomain(config, this.scale, domain);
       applyZero(config, this.scale);

--- a/packages/encodable/src/encoders/ChannelEncoder.ts
+++ b/packages/encodable/src/encoders/ChannelEncoder.ts
@@ -61,6 +61,7 @@ export default class ChannelEncoder<Def extends ChannelDef<Output>, Output exten
 
     if (this.definition.scale) {
       const scale = createScaleFromScaleConfig(this.definition.scale);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       this.encodeFunc = (value: ChannelInput) => scale(value as any) as Output;
       this.scale = scale;
     } else {

--- a/packages/encodable/src/parsers/format/createFormatterFromFieldTypeAndFormat.ts
+++ b/packages/encodable/src/parsers/format/createFormatterFromFieldTypeAndFormat.ts
@@ -11,12 +11,12 @@ export default function createFormatterFromFieldTypeAndFormat(
   if (type === 'quantitative') {
     const formatter = getNumberFormatter(format);
 
-    return (value: unknown) => formatter(value);
+    return (value: unknown) => formatter(value as number | null | undefined);
   }
   if (type === 'temporal') {
     const formatter = getTimeFormatter(format);
 
-    return (value: unknown) => formatter(value);
+    return (value: unknown) => formatter(value as Date | number | null | undefined);
   }
 
   return fallbackFormatter;

--- a/packages/encodable/src/parsers/scale/createScaleFromScaleConfig.ts
+++ b/packages/encodable/src/parsers/scale/createScaleFromScaleConfig.ts
@@ -1,7 +1,36 @@
-import { CategoricalColorNamespace } from '@superset-ui/color';
-import { ScaleOrdinal } from 'd3-scale';
+import { CategoricalColorNamespace, CategoricalColorScale } from '@superset-ui/color';
+import {
+  ScaleLinear,
+  ScaleLogarithmic,
+  ScalePower,
+  ScaleTime,
+  ScaleQuantile,
+  ScaleQuantize,
+  ScaleThreshold,
+  ScaleOrdinal,
+  ScalePoint,
+  ScaleBand,
+} from 'd3-scale';
 import { ScaleType, Value } from '../../types/VegaLite';
-import { ScaleConfig, CategoricalScaleInput } from '../../types/Scale';
+import {
+  ScaleConfig,
+  CategoricalScaleInput,
+  LinearScaleConfig,
+  LogScaleConfig,
+  PowScaleConfig,
+  SqrtScaleConfig,
+  SymlogScaleConfig,
+  TimeScaleConfig,
+  UtcScaleConfig,
+  QuantileScaleConfig,
+  QuantizeScaleConfig,
+  ThresholdScaleConfig,
+  BinOrdinalScaleConfig,
+  OrdinalScaleConfig,
+  PointScaleConfig,
+  BandScaleConfig,
+  AllScale,
+} from '../../types/Scale';
 import createScaleFromScaleType from './createScaleFromScaleType';
 import applyNice from './applyNice';
 import applyZero from './applyZero';
@@ -13,9 +42,55 @@ import applyPadding from './applyPadding';
 import applyAlign from './applyAlign';
 import applyClamp from './applyClamp';
 
-export default function createScaleFromScaleConfig<Output extends Value>(
+function createScaleFromScaleConfig<Output extends Value>(
+  config: LinearScaleConfig<Output>,
+): ScaleLinear<Output, Output>;
+
+function createScaleFromScaleConfig<Output extends Value>(
+  config: LogScaleConfig<Output> | SymlogScaleConfig<Output>,
+): ScaleLogarithmic<Output, Output>;
+
+function createScaleFromScaleConfig<Output extends Value>(
+  config: PowScaleConfig<Output> | SqrtScaleConfig<Output>,
+): ScalePower<Output, Output>;
+
+function createScaleFromScaleConfig<Output extends Value>(
+  config: TimeScaleConfig<Output> | UtcScaleConfig<Output>,
+): ScaleTime<Output, Output>;
+
+function createScaleFromScaleConfig<Output extends Value>(
+  config: QuantileScaleConfig<Output>,
+): ScaleQuantile<Output>;
+
+function createScaleFromScaleConfig<Output extends Value>(
+  config: QuantizeScaleConfig<Output>,
+): ScaleQuantize<Output>;
+
+function createScaleFromScaleConfig<Output extends Value>(
+  config: ThresholdScaleConfig<Output>,
+): ScaleThreshold<number | string | Date, Output>;
+
+function createScaleFromScaleConfig<Output extends Value>(
+  config: BinOrdinalScaleConfig<Output>,
+): ScaleOrdinal<CategoricalScaleInput, Output>;
+
+function createScaleFromScaleConfig<Output extends Value>(
+  config: OrdinalScaleConfig<Output>,
+): ScaleOrdinal<CategoricalScaleInput, Output> | CategoricalColorScale;
+
+function createScaleFromScaleConfig<Output extends Value>(
+  config: PointScaleConfig<Output>,
+): ScalePoint<CategoricalScaleInput>;
+
+function createScaleFromScaleConfig<Output extends Value>(
+  config: BandScaleConfig<Output>,
+): ScaleBand<CategoricalScaleInput>;
+
+function createScaleFromScaleConfig<Output extends Value>(
   config: ScaleConfig<Output>,
-) {
+): AllScale<Output>;
+
+function createScaleFromScaleConfig<Output extends Value>(config: ScaleConfig<Output>) {
   const { range } = config;
 
   // Handle categorical color scales
@@ -46,3 +121,5 @@ export default function createScaleFromScaleConfig<Output extends Value>(
 
   return scale;
 }
+
+export default createScaleFromScaleConfig;

--- a/packages/encodable/src/types/Scale.ts
+++ b/packages/encodable/src/types/Scale.ts
@@ -10,6 +10,7 @@ import {
   ScalePoint,
   ScaleBand,
 } from 'd3-scale';
+import { CategoricalColorScale } from '@superset-ui/color';
 import { Value, DateTime, NiceTime, ScaleType, Scale as VegaLiteScale } from './VegaLite';
 import { HasToString } from './Base';
 
@@ -231,4 +232,4 @@ export type D3Scale<Output extends Value = Value> =
   | ScalePoint<CategoricalScaleInput>
   | ScaleBand<CategoricalScaleInput>;
 
-export type AllScale<Output extends Value = Value> = D3Scale<Output> | ((val?: unknown) => string);
+export type AllScale<Output extends Value = Value> = D3Scale<Output> | CategoricalColorScale;

--- a/packages/encodable/test/encoders/ChannelEncoder.test.ts
+++ b/packages/encodable/test/encoders/ChannelEncoder.test.ts
@@ -245,7 +245,7 @@ describe('ChannelEncoder', () => {
       });
       expect(encoder.getDomain()).toEqual([0, 10]);
     });
-    it('returns empty array for CategoricalColorScale', () => {
+    it('returns domain for CategoricalColorScale', () => {
       const encoder = new ChannelEncoder({
         name: 'color',
         channelType: 'Color',
@@ -255,7 +255,7 @@ describe('ChannelEncoder', () => {
           scale: { domain: ['pocky', 'hanami'] },
         },
       });
-      expect(encoder.getDomain()).toEqual([]);
+      expect(encoder.getDomain()).toEqual(['pocky', 'hanami']);
     });
     it('returns empty array for value definition', () => {
       const encoder = new ChannelEncoder({

--- a/packages/encodable/test/parsers/scale/createScaleFromScaleConfig.test.ts
+++ b/packages/encodable/test/parsers/scale/createScaleFromScaleConfig.test.ts
@@ -554,7 +554,7 @@ describe('createScaleFromScaleConfig(config)', () => {
       });
       expect(scale('fish')).toEqual('pink');
       expect(scale('dinosaur')).toEqual('charcoal');
-      expect(scale('whale')).toEqual('pink');
+      expect(scale('whale')).toEqual('orange');
     });
     it('with color scheme and reversed domain', () => {
       const scale = createScaleFromScaleConfig({

--- a/packages/encodable/test/parsers/scale/createScaleFromScaleConfig.test.ts
+++ b/packages/encodable/test/parsers/scale/createScaleFromScaleConfig.test.ts
@@ -4,7 +4,6 @@ import {
   getCategoricalSchemeRegistry,
   CategoricalScheme,
 } from '@superset-ui/color';
-import { ScaleLinear, ScaleTime } from 'd3-scale';
 import createScaleFromScaleConfig from '../../../src/parsers/scale/createScaleFromScaleConfig';
 
 describe('createScaleFromScaleConfig(config)', () => {
@@ -145,7 +144,7 @@ describe('createScaleFromScaleConfig(config)', () => {
         range: [0, 100],
         nice: 3,
       });
-      expect((scale as ScaleLinear<number, number>).ticks(3)).toEqual([0, 5, 10]);
+      expect(scale.ticks(3)).toEqual([0, 5, 10]);
     });
     it('with clamp', () => {
       const scale = createScaleFromScaleConfig({
@@ -308,10 +307,7 @@ describe('createScaleFromScaleConfig(config)', () => {
         range: [0, 100],
         nice: 'month',
       });
-      expect((scale as ScaleTime<number, number>).domain()).toEqual([
-        new Date(2019, 6, 1),
-        new Date(2019, 7, 1),
-      ]);
+      expect(scale.domain()).toEqual([new Date(2019, 6, 1), new Date(2019, 7, 1)]);
     });
     it('with nice is interval object', () => {
       const scale = createScaleFromScaleConfig({
@@ -331,10 +327,7 @@ describe('createScaleFromScaleConfig(config)', () => {
         range: [0, 100],
         nice: { interval: 'month', step: 2 },
       });
-      expect((scale as ScaleTime<number, number>).domain()).toEqual([
-        new Date(2019, 6, 1),
-        new Date(2019, 8, 1),
-      ]);
+      expect(scale.domain()).toEqual([new Date(2019, 6, 1), new Date(2019, 8, 1)]);
     });
   });
 
@@ -382,7 +375,7 @@ describe('createScaleFromScaleConfig(config)', () => {
         range: [0, 100],
         nice: 'month',
       });
-      expect((scale as ScaleTime<number, number>).domain()).toEqual([
+      expect(scale.domain()).toEqual([
         new Date(Date.UTC(2019, 6, 1)),
         new Date(Date.UTC(2019, 7, 1)),
       ]);
@@ -407,7 +400,7 @@ describe('createScaleFromScaleConfig(config)', () => {
         range: [0, 100],
         nice: { interval: 'month', step: 2 },
       });
-      expect((scale as ScaleTime<number, number>).domain()).toEqual([
+      expect(scale.domain()).toEqual([
         new Date(Date.UTC(2019, 6, 1)),
         new Date(Date.UTC(2019, 8, 1)),
       ]);
@@ -432,7 +425,7 @@ describe('createScaleFromScaleConfig(config)', () => {
         range: [0, 100],
         nice: { interval: 'month', step: 0.5 },
       });
-      expect((scale as ScaleTime<number, number>).domain()).toEqual([
+      expect(scale.domain()).toEqual([
         new Date(Date.UTC(2019, 6, 5)),
         new Date(Date.UTC(2019, 6, 30)),
       ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2383,32 +2383,32 @@
   dependencies:
     type-detect "4.0.8"
 
-"@superset-ui/chart-composition@^0.12.5":
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/@superset-ui/chart-composition/-/chart-composition-0.12.5.tgz#24d727da31acdf75a31ec618f21ef6aed21b4abf"
-  integrity sha512-Fq/efLYfdwM3UUjObJx68U9+Xg7B2427hwsxVrlfH0YsdXWS+YVK7tZchIDFrm/CyOOzO3VONNQmpJrqDoFmIA==
+"@superset-ui/chart-composition@0.12.14":
+  version "0.12.14"
+  resolved "https://registry.yarnpkg.com/@superset-ui/chart-composition/-/chart-composition-0.12.14.tgz#291a23305d886b9d2358c0138a6dbee61edd23a4"
+  integrity sha512-FpiYhaDYcPaZytCx6r87wEp3oguYBkbonSWUOkZoY4ksPRgZ0bBWr8Wrwvk8zLaOCNF3jUdjXsKq/HPsRR3sKA==
   dependencies:
     "@types/react" "^16.7.17"
-    "@vx/responsive" "^0.0.192"
+    "@vx/responsive" "^0.0.195"
     csstype "^2.6.4"
 
-"@superset-ui/chart@^0.12.6":
-  version "0.12.6"
-  resolved "https://registry.yarnpkg.com/@superset-ui/chart/-/chart-0.12.6.tgz#90031c1877350fbc0f4a5d1c0f51e020567cecbb"
-  integrity sha512-pC3L3aewDXSn5nYRnSRILhjkWHNDTeefZbsPPdfyFUHArCa75SDMrELapSISNs9qiZ9PlAGmKooqpT0R59z/hg==
+"@superset-ui/chart@0.12.14":
+  version "0.12.14"
+  resolved "https://registry.yarnpkg.com/@superset-ui/chart/-/chart-0.12.14.tgz#9fc5485a01061fd9f35d0160ae5c770aedbe3446"
+  integrity sha512-LaCFoG8sfBu4ohhtTFVtQlp/fdN249toWtsm7MA1vMiLX1Sk5BPPMXCJUm1iQBYnbYp5WFF+LGIgV5pI/EsMtw==
   dependencies:
     "@types/react" "^16.7.17"
     "@types/react-loadable" "^5.4.2"
-    "@vx/responsive" "^0.0.192"
+    "@vx/responsive" "^0.0.195"
     prop-types "^15.6.2"
     react-error-boundary "^1.2.5"
     react-loadable "^5.5.0"
     reselect "^4.0.0"
 
-"@superset-ui/color@^0.12.5":
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/@superset-ui/color/-/color-0.12.5.tgz#0c0aab4047f9966afdc3e8a412feae31eed820bb"
-  integrity sha512-bjl85ymg0R8lw3T7shCthnlX76WZJ1tLyRNVTIziOogda+YssamkyvVAackFo1eggkbJzseXdse3vpos5+iZiw==
+"@superset-ui/color@0.12.15":
+  version "0.12.15"
+  resolved "https://registry.yarnpkg.com/@superset-ui/color/-/color-0.12.15.tgz#a69356667404d1e40d2eb22d3eb9f2d886fe4b38"
+  integrity sha512-xmZr+7FvPVRfN2XTx9sQJWgfDZw7YKtftXKU5ZWw3AygoBYcTt6ijFRJTL79hB9mtgNBX71oytuwKs9ixc8JeQ==
   dependencies:
     "@types/d3-scale" "^2.1.1"
     d3-scale "^3.0.0"
@@ -2426,73 +2426,79 @@
     conventional-changelog-cli "^2.0.12"
     cz-conventional-changelog "^2.1.0"
 
-"@superset-ui/connection@^0.12.5":
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/@superset-ui/connection/-/connection-0.12.5.tgz#2ca259fd85d5d2c017d337f09ad82be12c20dcef"
-  integrity sha512-HEpe8sgipjuibkW8y+Zi4agUE2Ju6PgBjGaj0FPWEn7y9V6cNA49uxJtEHSjb2f1TtO8DmdAr4VpCP1Wo7Jtuw==
+"@superset-ui/connection@0.12.14":
+  version "0.12.14"
+  resolved "https://registry.yarnpkg.com/@superset-ui/connection/-/connection-0.12.14.tgz#d433234183d427cdae6afdbc6e1114ade3b5a3da"
+  integrity sha512-fGdECjgO0J2nXV3U7XJKYzhaMVa5GYwqaeKyEp9p2UTT7k1BAfXxDzAPaFCVpwOfEvLillPFgVqB1MACYhcAbw==
   dependencies:
     "@babel/runtime" "^7.1.2"
     whatwg-fetch "^3.0.0"
 
-"@superset-ui/core@^0.12.5":
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/@superset-ui/core/-/core-0.12.5.tgz#87fdc074ed8dfe051f0453283fe29e3d76a3220f"
-  integrity sha512-IxyrZWTMXQcvFMms6B1DquF6PgSXdlh6u6iNizJAmXzd9OSmgrpn7cNN4je+ZPHzL5vlV2BUTJ28vnDlmJsEsw==
+"@superset-ui/core@0.12.15":
+  version "0.12.15"
+  resolved "https://registry.yarnpkg.com/@superset-ui/core/-/core-0.12.15.tgz#aa85ecfc7dd4a89a77e0da4e740b2879d0e2ae6e"
+  integrity sha512-YrLdEi2QFXrM/Bkwga774SShoHwQsBZh+we/a//AiMdBsE3Iht2rdUeZOYgdGXFXynilM8H5/KZlNra+OPYXuw==
   dependencies:
-    "@types/lodash" "4.14.149"
+    "@types/lodash" "^4.14.149"
     lodash "^4.17.11"
 
-"@superset-ui/dimension@^0.12.7":
-  version "0.12.7"
-  resolved "https://registry.yarnpkg.com/@superset-ui/dimension/-/dimension-0.12.7.tgz#01cf30e1d23806fb337dd6be5fc42282cbf10112"
-  integrity sha512-bTfr/FSxZbByUqOqBTzRbK83Q06YAg8iDNVTeWC3fmNQ0cdNqKSdh6GOiLlzbwFHOwi1tFYAyRlhfG4N33T9uw==
+"@superset-ui/dimension@0.12.14":
+  version "0.12.14"
+  resolved "https://registry.yarnpkg.com/@superset-ui/dimension/-/dimension-0.12.14.tgz#d7e4408f248f6ba8dc1de48d152985b9fedb3d47"
+  integrity sha512-r3YiFMg8WZ+fAyDU1EsU04EaJ6n4+WE2CdtuNTALmyQh3rxOyjhSxT35+7WEokr25pW3B3nVL9KMPW1fKJsPCA==
 
-"@superset-ui/number-format@^0.12.5":
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/@superset-ui/number-format/-/number-format-0.12.5.tgz#1ba3e4b6d0c15378a113bc167e6ce372d3b6aae2"
-  integrity sha512-lqC5zHAaKTfPjFF5ggdhHvJzA1M4hb/LT1Nu4gJlCfocbOD+SHLB94y2V/mx2I5EKK2lzEmY97m1hYdJ0Y7A/w==
+"@superset-ui/number-format@0.12.15":
+  version "0.12.15"
+  resolved "https://registry.yarnpkg.com/@superset-ui/number-format/-/number-format-0.12.15.tgz#6da94438a168abbd32f369893993bb8043c7ac5d"
+  integrity sha512-dUvg9ZkQcOI1k9IazU04IUmtu7EHQ/vmtcj4W26oo8Va6TnsjNI/471goTprY2j94Y8pBeiKVFJzcP7ad+MtBg==
   dependencies:
     "@types/d3-format" "^1.3.0"
     d3-format "^1.3.2"
-    pretty-ms "^5.0.0"
+    pretty-ms "^6.0.1"
 
-"@superset-ui/query@^0.12.5":
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/@superset-ui/query/-/query-0.12.5.tgz#9b2571cbdfc23857d4ca00becdb8deb9d14cc9c2"
-  integrity sha512-nSyVMtqavSlP/TOSUHHzyPnj58UnMU0Cp6KqODJd5IxPn34zQkshr772fhwt0QDDmOLZeD2cJxK7/76fwTSxaw==
+"@superset-ui/query@0.12.14":
+  version "0.12.14"
+  resolved "https://registry.yarnpkg.com/@superset-ui/query/-/query-0.12.14.tgz#d3710c0e794e26b33849666aa8f2c3f0fe4094fe"
+  integrity sha512-ZgPiwLSGIK5Ipc8scw2EVnDkYjaxjYmN1p/L+aPDPICOLjOcQWFGpr8hWYnVgS+yUZyKCOSVj0KSvZTuhZCNdg==
 
-"@superset-ui/superset-ui@^0.12.5":
-  version "0.12.7"
-  resolved "https://registry.yarnpkg.com/@superset-ui/superset-ui/-/superset-ui-0.12.7.tgz#3dc695f64ed77810e91076478a80bffdb206327e"
-  integrity sha512-xbG6aQeLPAmvEmpC4ShRF53clygA1A9sGgX6yW00WdlNbyLvSs+qrMPqdU9+U+pD8Dz3plnjMCGXo7Hvb88C4Q==
+"@superset-ui/superset-ui@^0.12.15":
+  version "0.12.15"
+  resolved "https://registry.yarnpkg.com/@superset-ui/superset-ui/-/superset-ui-0.12.15.tgz#9328263b0f09c116dd0835767e425ce25ea29a82"
+  integrity sha512-Rd+PMt3Yj1sgvVlSJUKhz9xyEPxULBHrwuMiNdRwr+e681qL5oNgrLpx/9Dr4L2QUqeKbdUYdcSKwD+7XeTmgw==
   dependencies:
-    "@superset-ui/chart" "^0.12.6"
-    "@superset-ui/chart-composition" "^0.12.5"
-    "@superset-ui/color" "^0.12.5"
-    "@superset-ui/connection" "^0.12.5"
-    "@superset-ui/core" "^0.12.5"
-    "@superset-ui/dimension" "^0.12.7"
-    "@superset-ui/number-format" "^0.12.5"
-    "@superset-ui/query" "^0.12.5"
-    "@superset-ui/time-format" "^0.12.5"
-    "@superset-ui/translation" "^0.12.5"
+    "@superset-ui/chart" "0.12.14"
+    "@superset-ui/chart-composition" "0.12.14"
+    "@superset-ui/color" "0.12.15"
+    "@superset-ui/connection" "0.12.14"
+    "@superset-ui/core" "0.12.15"
+    "@superset-ui/dimension" "0.12.14"
+    "@superset-ui/number-format" "0.12.15"
+    "@superset-ui/query" "0.12.14"
+    "@superset-ui/time-format" "0.12.15"
+    "@superset-ui/translation" "0.12.14"
+    "@superset-ui/validator" "0.12.14"
 
-"@superset-ui/time-format@^0.12.5":
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/@superset-ui/time-format/-/time-format-0.12.5.tgz#df7584768e00a17cbad990448b7b2fc4acd7af3f"
-  integrity sha512-y7lSUE8kkU0dJTUr+Vygfse43qb3s25t/OVcdpXuxhPEjH1ldWQImTrEllOmx6nKP1dl9AW3DcCGUHQYNzkl8g==
+"@superset-ui/time-format@0.12.15":
+  version "0.12.15"
+  resolved "https://registry.yarnpkg.com/@superset-ui/time-format/-/time-format-0.12.15.tgz#5d1d18956006fad79cee7ff5ab36d99d69372e60"
+  integrity sha512-AUT9ABiTk6/edpMFzFrBNPwhktvTovIKR1/pcfFH+z23ZckmusYIXJfqjGf20wcUdrSYCArdH6PelCvf2uJkNw==
   dependencies:
     "@types/d3-time" "^1.0.9"
     "@types/d3-time-format" "^2.1.0"
     d3-time "^1.0.10"
     d3-time-format "^2.2.0"
 
-"@superset-ui/translation@^0.12.5":
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/@superset-ui/translation/-/translation-0.12.5.tgz#97c5a6514ae109d09e356c09a0106a40b9cb869e"
-  integrity sha512-wIcMeA42yQs9eGRMbOAD9EQxdwF3xVdWjNh414KTWJwY3MSAUIAS9gFt2GvgTdiCQevTf6qK8OGzpk5kReQI1Q==
+"@superset-ui/translation@0.12.14":
+  version "0.12.14"
+  resolved "https://registry.yarnpkg.com/@superset-ui/translation/-/translation-0.12.14.tgz#f043f81a1a1db74a208143ac3a4b371771d8d4a7"
+  integrity sha512-Zd7Yx58OP3qonkzric5rg5gaQRJwHferDL/xIaKuYIqaK8BMPb2ZY+3TKSPkCm9mHLNnMi50jzZl8KYy5fv6Fg==
   dependencies:
     jed "^1.1.1"
+
+"@superset-ui/validator@0.12.14":
+  version "0.12.14"
+  resolved "https://registry.yarnpkg.com/@superset-ui/validator/-/validator-0.12.14.tgz#23216f89a9f8bcc4c99ad7e0c93a6c2e5afd710f"
+  integrity sha512-M1E67K/4LVOnbLLGwQf3ReHwTiR1SYugtK/0BpWrnLDdom2zeSpkh23Z1noOf4QUw3KcIqKtBnyvFaSbiQ+m9g==
 
 "@types/anymatch@*":
   version "1.3.1"
@@ -2672,7 +2678,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
-"@types/lodash@4.14.149", "@types/lodash@^4.14.149":
+"@types/lodash@^4.14.146", "@types/lodash@^4.14.149":
   version "4.14.149"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
   integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
@@ -2847,14 +2853,16 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@vx/responsive@^0.0.192":
-  version "0.0.192"
-  resolved "https://registry.yarnpkg.com/@vx/responsive/-/responsive-0.0.192.tgz#721d032bec38b9e3ff5fde2e4d5d8ee5a81cc517"
-  integrity sha512-HaXVwhSJXUfRbzRV+glxsX0ki2Hi1mdpz42iuGArVQgDPJEmBHjkXyoiXU8U6v66M7FAH+OyKgtc5j2bfhyYzA==
+"@vx/responsive@^0.0.195":
+  version "0.0.195"
+  resolved "https://registry.yarnpkg.com/@vx/responsive/-/responsive-0.0.195.tgz#8c75d86a28801c5f1970d43433a01e101454d444"
+  integrity sha512-3zjkjqg8V3Kr1moSI7EAzlW7MLR87p2CXc+qh0zZg/zLrc3C89JnxyMYFfS7jM4PlHr26n634YddQDVydwARBA==
   dependencies:
+    "@types/lodash" "^4.14.146"
+    "@types/react" "*"
     lodash "^4.17.10"
     prop-types "^15.6.1"
-    resize-observer-polyfill "1.5.0"
+    resize-observer-polyfill "1.5.1"
 
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
@@ -9047,10 +9055,17 @@ pretty-format@^25.1.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
-pretty-ms@^5.0.0, pretty-ms@^5.1.0:
+pretty-ms@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-5.1.0.tgz#b906bdd1ec9e9799995c372e2b1c34f073f95384"
   integrity sha512-4gaK1skD2gwscCfkswYQRmddUb2GJZtzDGRjHWadVHtK/DIKFufa12MvES6/xu1tVbUYeia5bmLcwJtZJQUqnw==
+  dependencies:
+    parse-ms "^2.1.0"
+
+pretty-ms@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-6.0.1.tgz#03ec6cfee20329f142645e63efad96bb775d3da4"
+  integrity sha512-ke4njoVmlotekHlHyCZ3wI/c5AMT8peuHs8rKJqekj/oR5G8lND2dVpicFlUz5cbZgE290vvkMuDwfj/OcW1kw==
   dependencies:
     parse-ms "^2.1.0"
 
@@ -9632,10 +9647,10 @@ reserved-words@^0.1.2:
   resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
   integrity sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=
 
-resize-observer-polyfill@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz#660ff1d9712a2382baa2cad450a4716209f9ca69"
-  integrity sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg==
+resize-observer-polyfill@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
🏆 Enhancements

Update after `CategoricalScale`, `NumberFormatter` and `TimeFormatter` are correctly typed as function.