### PR TITLE
fix: correctly handle input domain for quantile and discretizing scales

### DIFF
--- a/packages/encodable/src/encoders/ChannelEncoder.ts
+++ b/packages/encodable/src/encoders/ChannelEncoder.ts
@@ -119,6 +119,13 @@ export default class ChannelEncoder<Def extends ChannelDef<Output>, Output exten
       return Array.from(new Set(data.map(d => this.getValueFromDatum(d)))) as ChannelInput[];
     }
     if (type === 'quantitative') {
+      // Quantile scale needs all items
+      // because it treats domain as a discrete set of sample values
+      // for computing the quantiles
+      if (this.definition.scale && this.definition.scale.type === 'quantile') {
+        return data.map(d => this.getValueFromDatum<number>(d));
+      }
+
       const extent = d3Extent(data, d => this.getValueFromDatum<number>(d));
 
       return typeof extent[0] === 'undefined' ? [0, 1] : (extent as [number, number]);

--- a/packages/encodable/src/parsers/scale/applyDomain.ts
+++ b/packages/encodable/src/parsers/scale/applyDomain.ts
@@ -1,7 +1,7 @@
 import { Value } from '../../types/VegaLite';
 import { ScaleConfig, D3Scale } from '../../types/Scale';
 import inferElementTypeFromUnionOfArrayTypes from '../../utils/inferElementTypeFromUnionOfArrayTypes';
-import { isContinuousScale } from '../../typeGuards/Scale';
+import { isContinuousScale, isDiscretizingScale } from '../../typeGuards/Scale';
 import combineCategories from '../../utils/combineCategories';
 import parseDateTimeIfPossible from '../parseDateTimeIfPossible';
 import parseContinuousDomain from '../domain/parseContinuousDomain';
@@ -38,6 +38,10 @@ export default function applyDomain<Output extends Value>(
       if (combined) {
         scale.domain(order(combined));
       }
+    } else if (isDiscretizingScale(scale, type)) {
+      // For discretizing scales, if the domain is specified in config,
+      // use that and ignore the domain from dataset
+      scale.domain(order(parseContinuousDomain(fixedDomain, type)));
     } else {
       scale.domain(
         order(
@@ -51,6 +55,8 @@ export default function applyDomain<Output extends Value>(
   } else if (inputDomain) {
     if (isContinuousScale(scale, type)) {
       scale.domain(order(removeUndefinedAndNull(parseContinuousDomain(inputDomain, type))));
+    } else if (isDiscretizingScale(scale, type)) {
+      scale.domain(order(parseContinuousDomain(inputDomain, type)));
     } else {
       scale.domain(order(parseDiscreteDomain(inputDomain)));
     }

--- a/packages/encodable/src/parsers/scale/applyDomain.ts
+++ b/packages/encodable/src/parsers/scale/applyDomain.ts
@@ -30,7 +30,7 @@ export default function applyDomain<Output extends Value>(
   if (domain?.length) {
     const fixedDomain = inferElementTypeFromUnionOfArrayTypes(domain).map(parseDateTimeIfPossible);
 
-    if (isContinuousScale(scale, type)) {
+    if (isContinuousScale(scale, type) || isDiscretizingScale(scale, type)) {
       const combined = combineContinuousDomains(
         parseContinuousDomain(fixedDomain, type),
         inputDomain && removeUndefinedAndNull(parseContinuousDomain(inputDomain, type)),
@@ -38,10 +38,6 @@ export default function applyDomain<Output extends Value>(
       if (combined) {
         scale.domain(order(combined));
       }
-    } else if (isDiscretizingScale(scale, type)) {
-      // For discretizing scales, if the domain is specified in config,
-      // use that and ignore the domain from dataset
-      scale.domain(order(parseContinuousDomain(fixedDomain, type)));
     } else {
       scale.domain(
         order(
@@ -53,10 +49,8 @@ export default function applyDomain<Output extends Value>(
       );
     }
   } else if (inputDomain) {
-    if (isContinuousScale(scale, type)) {
+    if (isContinuousScale(scale, type) || isDiscretizingScale(scale, type)) {
       scale.domain(order(removeUndefinedAndNull(parseContinuousDomain(inputDomain, type))));
-    } else if (isDiscretizingScale(scale, type)) {
-      scale.domain(order(parseContinuousDomain(inputDomain, type)));
     } else {
       scale.domain(order(parseDiscreteDomain(inputDomain)));
     }

--- a/packages/encodable/src/typeGuards/Scale.ts
+++ b/packages/encodable/src/typeGuards/Scale.ts
@@ -11,9 +11,18 @@ import {
   TimeScaleConfig,
   UtcScaleConfig,
   ContinuousD3Scale,
+  DiscretizingD3Scale,
+  ThresholdScaleConfig,
+  QuantileScaleConfig,
+  QuantizeScaleConfig,
+  BinOrdinalScaleConfig,
 } from '../types/Scale';
 import { Value, ScaleType, SchemeParams } from '../types/VegaLite';
-import { timeScaleTypesSet, continuousScaleTypesSet } from '../parsers/scale/scaleCategories';
+import {
+  timeScaleTypesSet,
+  continuousScaleTypesSet,
+  discretizingScaleTypesSet,
+} from '../parsers/scale/scaleCategories';
 import isPropertySupportedByScaleType from '../parsers/scale/isPropertySupportedByScaleType';
 
 export function isContinuousScaleConfig<Output extends Value = Value>(
@@ -27,6 +36,16 @@ export function isContinuousScaleConfig<Output extends Value = Value>(
   | TimeScaleConfig<Output>
   | UtcScaleConfig<Output> {
   return continuousScaleTypesSet.has(config.type);
+}
+
+export function isDiscretizingScaleConfig<Output extends Value = Value>(
+  config: ScaleConfig,
+): config is
+  | ThresholdScaleConfig<Output>
+  | QuantileScaleConfig<Output>
+  | QuantizeScaleConfig<Output>
+  | BinOrdinalScaleConfig<Output> {
+  return discretizingScaleTypesSet.has(config.type);
 }
 
 export function isScaleConfigWithZero<Output extends Value = Value>(
@@ -56,6 +75,13 @@ export function isContinuousScale<Output extends Value = Value>(
   scaleType: ScaleType,
 ): scale is ContinuousD3Scale<Output> {
   return scale && continuousScaleTypesSet.has(scaleType);
+}
+
+export function isDiscretizingScale<Output extends Value = Value>(
+  scale: D3Scale<Output> | CategoricalColorScale,
+  scaleType: ScaleType,
+): scale is DiscretizingD3Scale<Output> {
+  return scale && discretizingScaleTypesSet.has(scaleType);
 }
 
 export function isTimeScale<Output extends Value = Value>(

--- a/packages/encodable/src/types/Scale.ts
+++ b/packages/encodable/src/types/Scale.ts
@@ -224,6 +224,12 @@ export type ContinuousD3Scale<Output extends Value = Value> =
   | ScalePower<Output, Output>
   | ScaleTime<Output, Output>;
 
+export type DiscretizingD3Scale<Output extends Value = Value> =
+  | ScaleQuantile<Output>
+  | ScaleQuantize<Output>
+  | ScaleThreshold<number | string | Date, Output>
+  | ScaleOrdinal<CategoricalScaleInput, Output>;
+
 export type D3Scale<Output extends Value = Value> =
   | ContinuousD3Scale<Output>
   | ScaleQuantile<Output>

--- a/packages/encodable/test/encoders/ChannelEncoder.test.ts
+++ b/packages/encodable/test/encoders/ChannelEncoder.test.ts
@@ -147,6 +147,32 @@ describe('ChannelEncoder', () => {
       });
     });
 
+    describe('for quantile scale', () => {
+      it('returns all possible values', () => {
+        const encoder = new ChannelEncoder({
+          name: 'pieColor',
+          channelType: 'Color',
+          definition: {
+            type: 'quantitative',
+            field: 'price',
+            scale: {
+              type: 'quantile',
+            },
+          },
+        });
+        expect(
+          encoder.getDomainFromDataset([
+            { price: 1 },
+            { price: 1 },
+            { price: 2 },
+            { price: 3 },
+            { price: 5 },
+            { price: 5 },
+          ]),
+        ).toEqual([1, 1, 2, 3, 5, 5]);
+      });
+    });
+
     describe('for ordinal field', () => {
       it('returns all possible values', () => {
         const encoder = new ChannelEncoder({

--- a/packages/encodable/test/parsers/scale/applyDomain.test.ts
+++ b/packages/encodable/test/parsers/scale/applyDomain.test.ts
@@ -1,16 +1,28 @@
-import { scaleLinear, scaleOrdinal } from 'd3-scale';
+import { scaleLinear, scaleOrdinal, scaleThreshold, scaleQuantile } from 'd3-scale';
 import applyDomain from '../../../src/parsers/scale/applyDomain';
 import { HasToString } from '../../../src/types/Base';
 
 describe('applyDomain()', () => {
   describe('with scale.domain', () => {
     describe('with domainFromDataset', () => {
-      it('continuous domain', () => {
+      it('continuous scales', () => {
         const scale = scaleLinear();
         applyDomain({ type: 'linear', domain: [null, 10] }, scale, [1, 20]);
         expect(scale.domain()).toEqual([1, 10]);
       });
-      it('discrete domain', () => {
+      describe('discretizing scales', () => {
+        it('threshold', () => {
+          const scale = scaleThreshold<string | number | Date, number>();
+          applyDomain({ type: 'threshold', domain: [0, 1, 10] }, scale, [1, 20]);
+          expect(scale.domain()).toEqual([0, 1, 10]);
+        });
+        it('quantile', () => {
+          const scale = scaleQuantile<number>();
+          applyDomain({ type: 'quantile', domain: [1, 1, 2, 3] }, scale, [1, 20]);
+          expect(scale.domain()).toEqual([1, 1, 2, 3]);
+        });
+      });
+      it('discrete scales', () => {
         const scale = scaleOrdinal<HasToString, string>();
         applyDomain(
           { type: 'ordinal', domain: ['a', 'c'], range: ['red', 'green', 'blue'] },
@@ -19,12 +31,12 @@ describe('applyDomain()', () => {
         );
         expect(scale.domain()).toEqual(['a', 'c', 'b']);
       });
-      it('continuous domain (reverse)', () => {
+      it('continuous scales (reverse)', () => {
         const scale = scaleLinear();
         applyDomain({ type: 'linear', domain: [null, 10], reverse: true }, scale, [1, 20]);
         expect(scale.domain()).toEqual([10, 1]);
       });
-      it('discrete domain (reverse)', () => {
+      it('discrete scales (reverse)', () => {
         const scale = scaleOrdinal<HasToString, string>();
         applyDomain(
           { type: 'ordinal', domain: ['a', 'c'], range: ['red', 'green', 'blue'], reverse: true },
@@ -35,12 +47,24 @@ describe('applyDomain()', () => {
       });
     });
     describe('without domainFromDataset', () => {
-      it('continuous domain', () => {
+      it('continuous scales', () => {
         const scale = scaleLinear();
         applyDomain({ type: 'linear', domain: [1, 10] }, scale);
         expect(scale.domain()).toEqual([1, 10]);
       });
-      it('discrete domain', () => {
+      describe('discretizing scales', () => {
+        it('threshold', () => {
+          const scale = scaleThreshold<string | number | Date, number>();
+          applyDomain({ type: 'threshold', domain: [0, 1, 10] }, scale);
+          expect(scale.domain()).toEqual([0, 1, 10]);
+        });
+        it('quantile', () => {
+          const scale = scaleQuantile<number>();
+          applyDomain({ type: 'quantile', domain: [1, 1, 2, 3] }, scale);
+          expect(scale.domain()).toEqual([1, 1, 2, 3]);
+        });
+      });
+      it('discrete scales', () => {
         const scale = scaleOrdinal<HasToString, string>();
         applyDomain(
           { type: 'ordinal', domain: ['a', 'c'], range: ['red', 'green', 'blue'] },
@@ -51,12 +75,24 @@ describe('applyDomain()', () => {
     });
   });
   describe('with domainFromDataset only', () => {
-    it('continuous domain', () => {
+    it('continuous scales', () => {
       const scale = scaleLinear();
       applyDomain({ type: 'linear' }, scale, [1, 20]);
       expect(scale.domain()).toEqual([1, 20]);
     });
-    it('discrete domain', () => {
+    describe('discretizing scales', () => {
+      it('threshold', () => {
+        const scale = scaleThreshold<string | number | Date, number>();
+        applyDomain({ type: 'threshold' }, scale, [1, 20]);
+        expect(scale.domain()).toEqual([1, 20]);
+      });
+      it('quantile', () => {
+        const scale = scaleQuantile<number>();
+        applyDomain({ type: 'quantile' }, scale, [1, 1, 2, 3, 5, 6]);
+        expect(scale.domain()).toEqual([1, 1, 2, 3, 5, 6]);
+      });
+    });
+    it('discrete scales', () => {
       const scale = scaleOrdinal<HasToString, string>();
       applyDomain({ type: 'ordinal', range: ['red', 'green', 'blue'] }, scale, ['a', 'b', 'c']);
       expect(scale.domain()).toEqual(['a', 'b', 'c']);

--- a/packages/encodable/test/typeGuards/Scale.test.ts
+++ b/packages/encodable/test/typeGuards/Scale.test.ts
@@ -1,13 +1,23 @@
 import { CategoricalColorScale } from '@superset-ui/color';
-import { scaleLinear, scaleOrdinal, scaleTime, scaleLog } from 'd3-scale';
+import {
+  scaleLinear,
+  scaleOrdinal,
+  scaleTime,
+  scaleLog,
+  scaleThreshold,
+  scaleQuantize,
+  scaleQuantile,
+} from 'd3-scale';
 import {
   isD3Scale,
   isCategoricalColorScale,
   isTimeScale,
   isContinuousScaleConfig,
+  isDiscretizingScaleConfig,
   isScaleConfigWithZero,
   isContinuousScale,
   isSchemeParams,
+  isDiscretizingScale,
 } from '../../src/typeGuards/Scale';
 import { HasToString } from '../../src/types/Base';
 
@@ -18,6 +28,17 @@ describe('type guards', () => {
     });
     it('returns false otherwise', () => {
       expect(isContinuousScaleConfig({ type: 'point' })).toBeFalsy();
+    });
+  });
+  describe('isDiscretizingScaleConfig(scaleConfig)', () => {
+    it('returns true if continuous', () => {
+      expect(isDiscretizingScaleConfig({ type: 'quantile' })).toBeTruthy();
+      expect(isDiscretizingScaleConfig({ type: 'quantize' })).toBeTruthy();
+      expect(isDiscretizingScaleConfig({ type: 'bin-ordinal' })).toBeTruthy();
+      expect(isDiscretizingScaleConfig({ type: 'threshold' })).toBeTruthy();
+    });
+    it('returns false otherwise', () => {
+      expect(isDiscretizingScaleConfig({ type: 'point' })).toBeFalsy();
     });
   });
   describe('isScaleConfigWithZero(scaleConfig)', () => {
@@ -46,11 +67,23 @@ describe('type guards', () => {
     });
   });
   describe('isContinuousScale(scale, type)', () => {
-    it('returns true if type is one of the time scale types', () => {
+    it('returns true if type is one of the continuous scale types', () => {
       expect(isContinuousScale(scaleLinear(), 'linear')).toBeTruthy();
     });
     it('returns false otherwise', () => {
       expect(isContinuousScale(scaleOrdinal<HasToString, string>(), 'ordinal')).toBeFalsy();
+    });
+  });
+  describe('isDiscretizingScale(scale, type)', () => {
+    it('returns true if type is one of the discretizing scale types', () => {
+      expect(
+        isDiscretizingScale<number>(scaleThreshold<string | number | Date, number>(), 'threshold'),
+      ).toBeTruthy();
+      expect(isDiscretizingScale<number>(scaleQuantize<number>(), 'quantize')).toBeTruthy();
+      expect(isDiscretizingScale<number>(scaleQuantile<number>(), 'quantile')).toBeTruthy();
+    });
+    it('returns false otherwise', () => {
+      expect(isDiscretizingScale(scaleLinear(), 'linear')).toBeFalsy();
     });
   });
   describe('isTimeScale(scale, type)', () => {


### PR DESCRIPTION
### 🏆  Enhancements

Previously the `extent [min, max]` was passed to the `quantile` scale as its domain, which is incorrect. Quantile scale needs all items because it treats domain as a discrete set of sample values for computing the quantiles.

Other discretizing scales (`threshold` and `quantize`) also need same domain treatment with continuous scales, which was not applied previously.