### PR TITLE
refactor: remove vega-lite imports with lean copies

### DIFF
--- a/packages/encodable/package.json
+++ b/packages/encodable/package.json
@@ -17,12 +17,10 @@
     "grammar",
     "visualization",
     "chart",
-    "encodable",
-    "vega-lite"
+    "encodable"
   ],
   "contributors": [
-    "Krist Wongsuphasawat (http://kristw.yellowpigz.com)",
-    "Chris Williams"
+    "Krist Wongsuphasawat (http://kristw.yellowpigz.com)"
   ],
   "license": "Apache-2.0",
   "bugs": {
@@ -43,9 +41,7 @@
     "d3-scale": "^3.0.1",
     "d3-time": "^1.0.11",
     "lodash": "^4.17.15",
-    "reselect": "^4.0.0",
-    "vega": "^5.9.1",
-    "vega-lite": "~4.1.0"
+    "reselect": "^4.0.0"
   },
   "devDependencies": {
     "@superset-ui/color": "^0.13.24",

--- a/packages/encodable/package.json
+++ b/packages/encodable/package.json
@@ -44,6 +44,7 @@
     "reselect": "^4.0.0"
   },
   "devDependencies": {
+    "jest-mock-console": "^1.0.1",
     "@superset-ui/color": "^0.13.24",
     "@superset-ui/core": "^0.13.21",
     "@superset-ui/number-format": "^0.13.3",

--- a/packages/encodable/src/encoders/ChannelEncoderAxis.ts
+++ b/packages/encodable/src/encoders/ChannelEncoderAxis.ts
@@ -2,12 +2,13 @@ import ChannelEncoder from './ChannelEncoder';
 import createFormatterFromFieldTypeAndFormat from '../parsers/format/createFormatterFromFieldTypeAndFormat';
 import { CompleteAxisConfig } from '../fillers/completeAxisConfig';
 import { ChannelDef } from '../types/ChannelDef';
-import { Value, isDateTime } from '../types/VegaLite';
+import { Value } from '../types/VegaLite';
 import { CompleteFieldDef } from '../types/CompleteChannelDef';
 import { ChannelInput } from '../types/Channel';
 import { HasToString } from '../types/Base';
 import parseDateTime from '../parsers/parseDateTime';
 import inferElementTypeFromUnionOfArrayTypes from '../utils/inferElementTypeFromUnionOfArrayTypes';
+import { isDateTime } from '../typeGuards/DateTime';
 
 export default class ChannelEncoderAxis<
   Def extends ChannelDef<Output>,

--- a/packages/encodable/src/parsers/dateTimeToTimestamp.ts
+++ b/packages/encodable/src/parsers/dateTimeToTimestamp.ts
@@ -67,7 +67,7 @@ function isNumeric(value: number | string): boolean {
   return !isNaN(value as any) && !isNaN(parseFloat(value));
 }
 
-function normalizeQuarter(q: number | string): number {
+export function normalizeQuarter(q: number | string): number {
   if (isNumeric(q)) {
     q = Number(q);
   }
@@ -84,7 +84,7 @@ function normalizeQuarter(q: number | string): number {
   throw new Error(invalidTimeUnit('quarter', q));
 }
 
-function normalizeMonth(m: string | number): number {
+export function normalizeMonth(m: string | number): number {
   if (isNumeric(m)) {
     m = Number(m);
   }
@@ -108,7 +108,7 @@ function normalizeMonth(m: string | number): number {
   throw new Error(invalidTimeUnit('month', m));
 }
 
-function normalizeDay(d: string | number): number {
+export function normalizeDay(d: string | number): number {
   if (isNumeric(d)) {
     d = Number(d);
   }
@@ -137,7 +137,7 @@ function normalizeDay(d: string | number): number {
  * @param normalize whether to normalize quarter, month, day. This should probably be true if d is a DateTime.
  * @returns array of date time parts [year, month, day, hours, minutes, seconds, milliseconds]
  */
-function dateTimeParts(d: DateTime | DateTimeExpr, normalize: boolean) {
+export function dateTimeParts(d: DateTime | DateTimeExpr, normalize: boolean) {
   const parts: (string | number)[] = [];
 
   if (normalize && d.day !== undefined) {

--- a/packages/encodable/src/parsers/dateTimeToTimestamp.ts
+++ b/packages/encodable/src/parsers/dateTimeToTimestamp.ts
@@ -1,0 +1,201 @@
+// Modified from vega-lite version
+// and remove unnecessary dependency
+
+/* eslint-disable no-param-reassign */
+/* eslint-disable no-negated-condition */
+import { DateTime } from '../types/VegaLite';
+import keys from '../utils/keys';
+
+/**
+ * Internal Object for defining datetime expressions.
+ * This is an expression version of DateTime.
+ * If both month and quarter are provided, month has higher precedence.
+ * `day` cannot be combined with other date.
+ */
+interface DateTimeExpr {
+  year?: string;
+  quarter?: string;
+  month?: string;
+  date?: string;
+  day?: string;
+  hours?: string;
+  minutes?: string;
+  seconds?: string;
+  milliseconds?: string;
+  utc?: boolean;
+}
+
+function invalidTimeUnit(unitName: string, value: string | number) {
+  return `Invalid ${unitName}: ${String(value)}.`;
+}
+
+/*
+ * A designated year that starts on Sunday.
+ */
+const SUNDAY_YEAR = 2006;
+
+const MONTHS = [
+  'january',
+  'february',
+  'march',
+  'april',
+  'may',
+  'june',
+  'july',
+  'august',
+  'september',
+  'october',
+  'november',
+  'december',
+];
+const SHORT_MONTHS = MONTHS.map(m => m.slice(0, 3));
+const DAYS = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+const SHORT_DAYS = DAYS.map(d => d.slice(0, 3));
+
+function isNumber(x: unknown): x is number {
+  return typeof x === 'number';
+}
+
+/**
+ * Returns whether the passed in value is a valid number.
+ */
+function isNumeric(value: number | string): boolean {
+  if (isNumber(value)) {
+    return true;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return !isNaN(value as any) && !isNaN(parseFloat(value));
+}
+
+function normalizeQuarter(q: number | string): number {
+  if (isNumeric(q)) {
+    q = Number(q);
+  }
+
+  if (isNumber(q)) {
+    if (q > 4) {
+      // eslint-disable-next-line no-console
+      console.warn(invalidTimeUnit('quarter', q));
+    }
+    // We accept 1-based quarter, so need to readjust to 0-based quarter
+    return q - 1;
+  }
+  // Invalid quarter
+  throw new Error(invalidTimeUnit('quarter', q));
+}
+
+function normalizeMonth(m: string | number): number {
+  if (isNumeric(m)) {
+    m = Number(m);
+  }
+
+  if (isNumber(m)) {
+    // We accept 1-based month, so need to readjust to 0-based month
+    return m - 1;
+  }
+  const lowerM = m.toLowerCase();
+  const monthIndex = MONTHS.indexOf(lowerM);
+  if (monthIndex !== -1) {
+    return monthIndex; // 0 for january, ...
+  }
+  const shortM = lowerM.slice(0, 3);
+  const shortMonthIndex = SHORT_MONTHS.indexOf(shortM);
+  if (shortMonthIndex !== -1) {
+    return shortMonthIndex;
+  }
+
+  // Invalid month
+  throw new Error(invalidTimeUnit('month', m));
+}
+
+function normalizeDay(d: string | number): number {
+  if (isNumeric(d)) {
+    d = Number(d);
+  }
+
+  if (isNumber(d)) {
+    // mod so that this can be both 0-based where 0 = sunday
+    // and 1-based where 7=sunday
+    return d % 7;
+  }
+  const lowerD = d.toLowerCase();
+  const dayIndex = DAYS.indexOf(lowerD);
+  if (dayIndex !== -1) {
+    return dayIndex; // 0 for january, ...
+  }
+  const shortD = lowerD.slice(0, 3);
+  const shortDayIndex = SHORT_DAYS.indexOf(shortD);
+  if (shortDayIndex !== -1) {
+    return shortDayIndex;
+  }
+  // Invalid day
+  throw new Error(invalidTimeUnit('day', d));
+}
+
+/**
+ * @param d the date.
+ * @param normalize whether to normalize quarter, month, day. This should probably be true if d is a DateTime.
+ * @returns array of date time parts [year, month, day, hours, minutes, seconds, milliseconds]
+ */
+function dateTimeParts(d: DateTime | DateTimeExpr, normalize: boolean) {
+  const parts: (string | number)[] = [];
+
+  if (normalize && d.day !== undefined) {
+    if (keys(d).length > 1) {
+      d = { ...d };
+      delete d.day;
+    }
+  }
+
+  if (d.year !== undefined) {
+    parts.push(d.year);
+  } else if (d.day !== undefined) {
+    // Set year to 2006 for working with day since January 1 2006 is a Sunday
+    parts.push(SUNDAY_YEAR);
+  } else {
+    parts.push(0);
+  }
+
+  if (d.month !== undefined) {
+    const month = normalize ? normalizeMonth(d.month) : d.month;
+    parts.push(month);
+  } else if (d.quarter !== undefined) {
+    const quarter = normalize ? normalizeQuarter(d.quarter) : d.quarter;
+    parts.push(isNumber(quarter) ? quarter * 3 : `${quarter}*3`);
+  } else {
+    parts.push(0); // months start at zero in JS
+  }
+
+  if (d.date !== undefined) {
+    parts.push(d.date);
+  } else if (d.day !== undefined) {
+    // HACK: Day only works as a standalone unit
+    // This is only correct because we always set year to 2006 for day
+    const day = normalize ? normalizeDay(d.day) : d.day;
+    parts.push(isNumber(day) ? day + 1 : `${day}+1`);
+  } else {
+    parts.push(1); // Date starts at 1 in JS
+  }
+
+  (['hours', 'minutes', 'seconds', 'milliseconds'] as const).forEach(timeUnit => {
+    const unit = d[timeUnit];
+    parts.push(typeof unit === 'undefined' ? 0 : unit);
+  });
+
+  return parts;
+}
+
+/**
+ * @param d the date time.
+ * @returns the timestamp.
+ */
+export default function dateTimeToTimestamp(d: DateTime) {
+  const parts: (string | number)[] = dateTimeParts(d, true);
+
+  if (d.utc) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return Number(new Date(Date.UTC(...(parts as [any, any]))));
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return Number(new Date(...(parts as [any])));
+}

--- a/packages/encodable/src/parsers/parseDateTime.ts
+++ b/packages/encodable/src/parsers/parseDateTime.ts
@@ -1,5 +1,5 @@
-import { dateTimeToTimestamp } from 'vega-lite/build/src/datetime';
 import { DateTime } from '../types/VegaLite';
+import dateTimeToTimestamp from './dateTimeToTimestamp';
 
 export default function parseDateTime(dateTime: string | number | DateTime) {
   if (typeof dateTime === 'number' || typeof dateTime === 'string') {

--- a/packages/encodable/src/parsers/parseDateTimeIfPossible.ts
+++ b/packages/encodable/src/parsers/parseDateTimeIfPossible.ts
@@ -1,4 +1,5 @@
-import { DateTime, isDateTime } from '../types/VegaLite';
+import { DateTime } from '../types/VegaLite';
+import { isDateTime } from '../typeGuards/DateTime';
 import parseDateTime from './parseDateTime';
 
 export default function parseDateTimeIfPossible<T>(d: DateTime | T) {

--- a/packages/encodable/src/typeGuards/DateTime.ts
+++ b/packages/encodable/src/typeGuards/DateTime.ts
@@ -1,17 +1,21 @@
 import { DateTime } from '../types/VegaLite/DateTime';
 
-// eslint-disable-next-line import/prefer-default-export, @typescript-eslint/no-explicit-any
-export function isDateTime(o: any): o is DateTime {
+// eslint-disable-next-line import/prefer-default-export
+export function isDateTime(o: string | number | boolean | DateTime): o is DateTime {
   return (
     !!o &&
-    (!!o.year ||
-      !!o.quarter ||
-      !!o.month ||
-      !!o.date ||
-      !!o.day ||
-      !!o.hours ||
-      !!o.minutes ||
-      !!o.seconds ||
-      !!o.milliseconds)
+    !(o instanceof Date) &&
+    typeof o !== 'string' &&
+    typeof o !== 'boolean' &&
+    typeof o !== 'number' &&
+    (('year' in o && o.year != null) ||
+      ('quarter' in o && o.quarter != null) ||
+      ('month' in o && o.month != null) ||
+      ('date' in o && o.date != null) ||
+      ('day' in o && o.day != null) ||
+      ('hours' in o && o.hours != null) ||
+      ('minutes' in o && o.minutes != null) ||
+      ('seconds' in o && o.seconds != null) ||
+      ('milliseconds' in o && o.milliseconds != null))
   );
 }

--- a/packages/encodable/src/typeGuards/DateTime.ts
+++ b/packages/encodable/src/typeGuards/DateTime.ts
@@ -1,0 +1,17 @@
+import { DateTime } from '../types/VegaLite/DateTime';
+
+// eslint-disable-next-line import/prefer-default-export, @typescript-eslint/no-explicit-any
+export function isDateTime(o: any): o is DateTime {
+  return (
+    !!o &&
+    (!!o.year ||
+      !!o.quarter ||
+      !!o.month ||
+      !!o.date ||
+      !!o.day ||
+      !!o.hours ||
+      !!o.minutes ||
+      !!o.seconds ||
+      !!o.milliseconds)
+  );
+}

--- a/packages/encodable/src/types/Scale.ts
+++ b/packages/encodable/src/types/Scale.ts
@@ -11,8 +11,14 @@ import {
   ScaleBand,
 } from 'd3-scale';
 import { CategoricalColorScale } from '@superset-ui/color';
-import { SchemeParams } from 'vega-lite/build/src/scale';
-import { Value, DateTime, NiceTime, ScaleType, Scale as VegaLiteScale } from './VegaLite';
+import {
+  Value,
+  DateTime,
+  NiceTime,
+  ScaleType,
+  Scale as VegaLiteScale,
+  SchemeParams,
+} from './VegaLite';
 import { HasToString } from './Base';
 
 // Pick properties inherited from vega-lite

--- a/packages/encodable/src/types/VegaLite/Axis.ts
+++ b/packages/encodable/src/types/VegaLite/Axis.ts
@@ -1,0 +1,51 @@
+import { DateTime } from './DateTime';
+import { TitleMixins, FormatMixins } from './Mixins';
+
+interface Guide extends TitleMixins, FormatMixins {}
+
+// Override: Flatten types from both vega and vega-lite
+// only selected a small subset of fields
+export interface Axis extends Guide {
+  /**
+   * The rotation angle of the axis labels.
+   *
+   * __Default value:__ `-90` for nominal and ordinal fields; `0` otherwise.
+   *
+   * @minimum -360
+   * @maximum 360
+   */
+  labelAngle?: number;
+
+  /**
+   * Indicates if the first and last axis labels should be aligned flush with the scale range. Flush alignment for a horizontal axis will left-align the first label and right-align the last label. For vertical axes, bottom and top text baselines are applied instead. If this property is a number, it also indicates the number of pixels by which to offset the first and last labels; for example, a value of 2 will flush-align the first and last labels and also push them 2 pixels outward from the center of the axis. The additional adjustment can sometimes help the labels better visually group with corresponding axis ticks.
+   *
+   * __Default value:__ `true` for axis of a continuous x-scale. Otherwise, `false`.
+   */
+  labelFlush?: boolean | number;
+
+  /**
+   * Boolean value that determines whether the axis should include ticks.
+   *
+   * __Default value:__ `true`
+   */
+  ticks?: boolean;
+
+  /**
+   * A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are "nice" (multiples of 2, 5, 10) and lie within the underlying scale's range.
+   *
+   * __Default value__: Determine using a formula `ceil(width/40)` for x and `ceil(height/40)` for y.
+   *
+   * @minimum 0
+   */
+  tickCount?: number;
+
+  /**
+   * The padding, in pixels, between title and axis.
+   */
+  titlePadding?: number;
+
+  /**
+   * Explicitly set the visible axis tick values.
+   */
+  values?: number[] | string[] | boolean[] | DateTime[];
+}

--- a/packages/encodable/src/types/VegaLite/DateTime.ts
+++ b/packages/encodable/src/types/VegaLite/DateTime.ts
@@ -1,0 +1,99 @@
+// Inherited from Vega-Lite
+
+/**
+ * @minimum 1
+ * @maximum 12
+ * @TJS-type integer
+ */
+export type Month = number;
+
+/**
+ * @minimum 1
+ * @maximum 7
+ */
+export type Day = number;
+
+/**
+ * Object for defining datetime in Vega-Lite Filter.
+ * If both month and quarter are provided, month has higher precedence.
+ * `day` cannot be combined with other date.
+ * We accept string for month and day names.
+ */
+export interface DateTime {
+  /**
+   * Integer value representing the year.
+   * @TJS-type integer
+   */
+  year?: number;
+
+  /**
+   * Integer value representing the quarter of the year (from 1-4).
+   * @minimum 1
+   * @maximum 4
+   * @TJS-type integer
+   */
+  quarter?: number;
+
+  /**
+   * One of:
+   * (1) integer value representing the month from `1`-`12`. `1` represents January;
+   * (2) case-insensitive month name (e.g., `"January"`);
+   * (3) case-insensitive, 3-character short month name (e.g., `"Jan"`).
+   */
+  month?: Month | string;
+
+  /**
+   * Integer value representing the date (day of the month) from 1-31.
+   * @minimum 1
+   * @maximum 31
+   * @TJS-type integer
+   */
+  date?: number;
+
+  /**
+   * Value representing the day of a week. This can be one of:
+   * (1) integer value -- `1` represents Monday;
+   * (2) case-insensitive day name (e.g., `"Monday"`);
+   * (3) case-insensitive, 3-character short day name (e.g., `"Mon"`).
+   *
+   * **Warning:** A DateTime definition object with `day`** should not be combined with `year`, `quarter`, `month`, or `date`.
+   */
+  day?: Day | string;
+
+  /**
+   * Integer value representing the hour of a day from 0-23.
+   * @minimum 0
+   * @maximum 23
+   * @TJS-type integer
+   */
+  hours?: number;
+
+  /**
+   * Integer value representing the minute segment of time from 0-59.
+   * @minimum 0
+   * @maximum 59
+   * @TJS-type integer
+   */
+  minutes?: number;
+
+  /**
+   * Integer value representing the second segment (0-59) of a time value
+   * @minimum 0
+   * @maximum 59
+   * @TJS-type integer
+   */
+  seconds?: number;
+
+  /**
+   * Integer value representing the millisecond segment of time.
+   * @minimum 0
+   * @maximum 999
+   * @TJS-type integer
+   */
+  milliseconds?: number;
+
+  /**
+   * A boolean flag indicating if date time is in utc time. If false, the date time is in local time
+   */
+  utc?: boolean;
+}

--- a/packages/encodable/src/types/VegaLite/Mixins.ts
+++ b/packages/encodable/src/types/VegaLite/Mixins.ts
@@ -1,0 +1,44 @@
+export interface TitleMixins {
+  /**
+   * A title for the field. If `null`, the title will be removed.
+   *
+   * __Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`). If the field has an aggregate function, the function is displayed as part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `"Profit (binned)"`, `"Transaction Date (year-month)"`). Otherwise, the title is simply the field name.
+   *
+   * __Notes__:
+   *
+   * 1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).
+   *
+   * 2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.
+   */
+  title?: Text | null;
+}
+
+export interface FormatMixins {
+  /**
+   * The text formatting pattern for labels of guides (axes, legends, headers) and text marks.
+   *
+   * - If the format type is `"number"` (e.g., for quantitative fields), this is D3's [number format pattern](https://github.com/d3/d3-format#locale_format).
+   * - If the format type is `"time"` (e.g., for temporal fields), this is D3's [time format pattern](https://github.com/d3/d3-time-format#locale_format).
+   *
+   * See the [format documentation](https://vega.github.io/vega-lite/docs/format.html) for more examples.
+   *
+   * __Default value:__  Derived from [numberFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for number format and from [timeFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for time format.
+   */
+  format?: string;
+
+  /**
+   * The format type for labels (`"number"` or `"time"`).
+   *
+   * __Default value:__
+   * - `"time"` for temporal fields and ordinal and nomimal fields with `timeUnit`.
+   * - `"number"` for quantitative fields as well as ordinal and nomimal fields without `timeUnit`.
+   */
+  formatType?: 'number' | 'time';
+
+  /**
+   * [Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels text.
+   *
+   * __Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.
+   */
+  labelExpr?: string;
+}

--- a/packages/encodable/src/types/VegaLite/Mixins.ts
+++ b/packages/encodable/src/types/VegaLite/Mixins.ts
@@ -11,7 +11,7 @@ export interface TitleMixins {
    *
    * 2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.
    */
-  title?: string | Text | null;
+  title?: string | null;
 }
 
 export interface FormatMixins {

--- a/packages/encodable/src/types/VegaLite/Mixins.ts
+++ b/packages/encodable/src/types/VegaLite/Mixins.ts
@@ -1,3 +1,4 @@
+// Also allow string in title
 export interface TitleMixins {
   /**
    * A title for the field. If `null`, the title will be removed.
@@ -10,7 +11,7 @@ export interface TitleMixins {
    *
    * 2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.
    */
-  title?: Text | null;
+  title?: string | Text | null;
 }
 
 export interface FormatMixins {

--- a/packages/encodable/src/types/VegaLite/Scale.ts
+++ b/packages/encodable/src/types/VegaLite/Scale.ts
@@ -1,0 +1,206 @@
+import { ScaleType } from './ScaleType';
+import { DateTime } from './DateTime';
+import { SchemeParams } from './SchemeParams';
+
+export type ScaleInterpolate =
+  | 'rgb'
+  | 'lab'
+  | 'hcl'
+  | 'hsl'
+  | 'hsl-long'
+  | 'hcl-long'
+  | 'cubehelix'
+  | 'cubehelix-long';
+
+export interface ScaleInterpolateParams {
+  type: 'rgb' | 'cubehelix' | 'cubehelix-long';
+  gamma?: number;
+}
+
+export type NiceTime = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
+
+export interface Scale {
+  /**
+   * The type of scale. Vega-Lite supports the following categories of scale types:
+   *
+   * 1) [**Continuous Scales**](https://vega.github.io/vega-lite/docs/scale.html#continuous) -- mapping continuous domains to continuous output ranges ([`"linear"`](https://vega.github.io/vega-lite/docs/scale.html#linear), [`"pow"`](https://vega.github.io/vega-lite/docs/scale.html#pow), [`"sqrt"`](https://vega.github.io/vega-lite/docs/scale.html#sqrt), [`"symlog"`](https://vega.github.io/vega-lite/docs/scale.html#symlog), [`"log"`](https://vega.github.io/vega-lite/docs/scale.html#log), [`"time"`](https://vega.github.io/vega-lite/docs/scale.html#time), [`"utc"`](https://vega.github.io/vega-lite/docs/scale.html#utc).
+   *
+   * 2) [**Discrete Scales**](https://vega.github.io/vega-lite/docs/scale.html#discrete) -- mapping discrete domains to discrete ([`"ordinal"`](https://vega.github.io/vega-lite/docs/scale.html#ordinal)) or continuous ([`"band"`](https://vega.github.io/vega-lite/docs/scale.html#band) and [`"point"`](https://vega.github.io/vega-lite/docs/scale.html#point)) output ranges.
+   *
+   * 3) [**Discretizing Scales**](https://vega.github.io/vega-lite/docs/scale.html#discretizing) -- mapping continuous domains to discrete output ranges [`"bin-ordinal"`](https://vega.github.io/vega-lite/docs/scale.html#bin-ordinal), [`"quantile"`](https://vega.github.io/vega-lite/docs/scale.html#quantile), [`"quantize"`](https://vega.github.io/vega-lite/docs/scale.html#quantize) and [`"threshold"`](https://vega.github.io/vega-lite/docs/scale.html#threshold).
+   *
+   * __Default value:__ please see the [scale type table](https://vega.github.io/vega-lite/docs/scale.html#type).
+   */
+  type?: ScaleType;
+
+  // Override: Remove selectionExtent | 'unaggregated'
+  /**
+   * Customized domain values.
+   *
+   * For _quantitative_ fields, `domain` can take the form of a two-element array with minimum and maximum values. [Piecewise scales](https://vega.github.io/vega-lite/docs/scale.html#piecewise) can be created by providing a `domain` with more than two entries.
+   * If the input field is aggregated, `domain` can also be a string value `"unaggregated"`, indicating that the domain should include the raw data values prior to the aggregation.
+   *
+   * For _temporal_ fields, `domain` can be a two-element array minimum and maximum values, in the form of either timestamps or the [DateTime definition objects](https://vega.github.io/vega-lite/docs/types.html#datetime).
+   *
+   * For _ordinal_ and _nominal_ fields, `domain` can be an array that lists valid input values.
+   *
+   * The `selection` property can be used to [interactively determine](https://vega.github.io/vega-lite/docs/selection.html#scale-domains) the scale domain.
+   */
+  domain?: number[] | string[] | boolean[] | DateTime[];
+
+  /**
+   * Inserts a single mid-point value into a two-element domain. The mid-point value must lie between the domain minimum and maximum values. This property can be useful for setting a midpoint for [diverging color scales](https://vega.github.io/vega-lite/docs/scale.html#piecewise). The domainMid property is only intended for use with scales supporting continuous, piecewise domains.
+   */
+  domainMid?: number;
+
+  // Hide because we might not really need this.
+  /**
+   * If true, reverses the order of the scale range.
+   * __Default value:__ `false`.
+   *
+   * @hidden
+   */
+  reverse?: boolean;
+
+  // Override: Remove RangeEnum
+  /**
+   * The range of the scale. One of:
+   *
+   * - A string indicating a [pre-defined named scale range](https://vega.github.io/vega-lite/docs/scale.html#range-config) (e.g., example, `"symbol"`, or `"diverging"`).
+   *
+   * - For [continuous scales](https://vega.github.io/vega-lite/docs/scale.html#continuous), two-element array indicating  minimum and maximum values, or an array with more than two entries for specifying a [piecewise scale](https://vega.github.io/vega-lite/docs/scale.html#piecewise).
+   *
+   * - For [discrete](https://vega.github.io/vega-lite/docs/scale.html#discrete) and [discretizing](https://vega.github.io/vega-lite/docs/scale.html#discretizing) scales, an array of desired output values.
+   *
+   * __Notes:__
+   *
+   * 1) For color scales you can also specify a color [`scheme`](https://vega.github.io/vega-lite/docs/scale.html#scheme) instead of `range`.
+   *
+   * 2) Any directly specified `range` for `x` and `y` channels will be ignored. Range can be customized via the view's corresponding [size](https://vega.github.io/vega-lite/docs/size.html) (`width` and `height`).
+   */
+  range?: number[] | string[];
+
+  // ordinal
+
+  /**
+   * A string indicating a color [scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme) name (e.g., `"category10"` or `"blues"`) or a [scheme parameter object](https://vega.github.io/vega-lite/docs/scale.html#scheme-params).
+   *
+   * Discrete color schemes may be used with [discrete](https://vega.github.io/vega-lite/docs/scale.html#discrete) or [discretizing](https://vega.github.io/vega-lite/docs/scale.html#discretizing) scales. Continuous color schemes are intended for use with color scales.
+   *
+   * For the full list of supported schemes, please refer to the [Vega Scheme](https://vega.github.io/vega/docs/schemes/#reference) reference.
+   */
+  scheme?: string | SchemeParams;
+
+  /**
+   * The alignment of the steps within the scale range.
+   *
+   * This value must lie in the range `[0,1]`. A value of `0.5` indicates that the steps should be centered within the range. A value of `0` or `1` may be used to shift the bands to one side, say to position them adjacent to an axis.
+   *
+   * __Default value:__ `0.5`
+   */
+  align?: number;
+
+  /**
+   * An array of bin boundaries over the scale domain. If provided, axes and legends will use the bin boundaries to inform the choice of tick marks and text labels.
+   */
+  bins?: number[];
+
+  /**
+   * If `true`, rounds numeric output values to integers. This can be helpful for snapping to the pixel grid.
+   *
+   * __Default value:__ `false`.
+   */
+  round?: boolean;
+
+  /**
+   * For _[continuous](https://vega.github.io/vega-lite/docs/scale.html#continuous)_ scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended.
+   * Padding adjustment is performed prior to all other adjustments, including the effects of the `zero`, `nice`, `domainMin`, and `domainMax` properties.
+   *
+   * For _[band](https://vega.github.io/vega-lite/docs/scale.html#band)_ scales, shortcut for setting `paddingInner` and `paddingOuter` to the same value.
+   *
+   * For _[point](https://vega.github.io/vega-lite/docs/scale.html#point)_ scales, alias for `paddingOuter`.
+   *
+   * __Default value:__ For _continuous_ scales, derived from the [scale config](https://vega.github.io/vega-lite/docs/scale.html#config)'s `continuousPadding`.
+   * For _band and point_ scales, see `paddingInner` and `paddingOuter`. By default, Vega-Lite sets padding such that _width/height = number of unique values * step_.
+   *
+   * @minimum 0
+   */
+  padding?: number;
+
+  /**
+   * The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1].
+   *
+   * For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands).
+   *
+   * __Default value:__ derived from the [scale config](https://vega.github.io/vega-lite/docs/scale.html#config)'s `bandPaddingInner`.
+   *
+   * @minimum 0
+   * @maximum 1
+   */
+  paddingInner?: number;
+
+  /**
+   * The outer padding (spacing) at the ends of the range of band and point scales,
+   * as a fraction of the step size. This value must lie in the range [0,1].
+   *
+   * __Default value:__ derived from the [scale config](https://vega.github.io/vega-lite/docs/scale.html#config)'s `bandPaddingOuter` for band scales and `pointPadding` for point scales.
+   * By default, Vega-Lite sets outer padding such that _width/height = number of unique values * step_.
+   *
+   * @minimum 0
+   * @maximum 1
+   */
+  paddingOuter?: number;
+
+  // typical
+  /**
+   * If `true`, values that exceed the data domain are clamped to either the minimum or maximum range value
+   *
+   * __Default value:__ derived from the [scale config](https://vega.github.io/vega-lite/docs/config.html#scale-config)'s `clamp` (`true` by default).
+   */
+  clamp?: boolean;
+
+  /**
+   * Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of _[0.201479…, 0.996679…]_, a nice domain might be _[0.2, 1.0]_.
+   *
+   * For quantitative scales such as linear, `nice` can be either a boolean flag or a number. If `nice` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain.
+   *
+   * For temporal fields with time and utc scales, the `nice` value can be a string indicating the desired time interval. Legal values are `"millisecond"`, `"second"`, `"minute"`, `"hour"`, `"day"`, `"week"`, `"month"`, and `"year"`. Alternatively, `time` and `utc` scales can accept an object-valued interval specifier of the form `{"interval": "month", "step": 3}`, which includes a desired number of interval steps. Here, the domain would snap to quarter (Jan, Apr, Jul, Oct) boundaries.
+   *
+   * __Default value:__ `true` for unbinned _quantitative_ fields; `false` otherwise.
+   *
+   */
+  nice?: boolean | number | NiceTime | { interval: string; step: number };
+
+  /**
+   * The logarithm base of the `log` scale (default `10`).
+   */
+  base?: number;
+
+  /**
+   * The exponent of the `pow` scale.
+   */
+  exponent?: number;
+
+  /**
+   * A constant determining the slope of the symlog function around zero. Only used for `symlog` scales.
+   *
+   * __Default value:__ `1`
+   */
+  constant?: number;
+
+  /**
+   * If `true`, ensures that a zero baseline value is included in the scale domain.
+   *
+   * __Default value:__ `true` for x and y channels if the quantitative field is not binned and no custom `domain` is provided; `false` otherwise.
+   *
+   * __Note:__ Log, time, and utc scales do not support `zero`.
+   */
+  zero?: boolean;
+
+  /**
+   * The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include `rgb`, `hsl`, `hsl-long`, `lab`, `hcl`, `hcl-long`, `cubehelix` and `cubehelix-long` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued _type_ property and an optional numeric _gamma_ property applicable to rgb and cubehelix interpolators. For more, see the [d3-interpolate documentation](https://github.com/d3/d3-interpolate).
+   *
+   * * __Default value:__ `hcl`
+   */
+  interpolate?: ScaleInterpolate | ScaleInterpolateParams;
+}

--- a/packages/encodable/src/types/VegaLite/ScaleType.ts
+++ b/packages/encodable/src/types/VegaLite/ScaleType.ts
@@ -1,13 +1,6 @@
-import { ValueOf } from './Base';
+import { ValueOf } from '../Base';
 
-// Types imported from vega-lite
-export { ValueDef, Value } from 'vega-lite/build/src/channeldef';
-export { isDateTime, DateTime } from 'vega-lite/build/src/datetime';
-export { SchemeParams, Scale, NiceTime } from 'vega-lite/build/src/scale';
-export { Axis } from 'vega-lite/build/src/axis';
-export { Type } from 'vega-lite/build/src/type';
-
-// Override this implementation
+// Modified from vega-lite
 // because vega-lite uses namespace which has issues with babel and typescript
 export const ScaleType = {
   // Continuous - Quantitative

--- a/packages/encodable/src/types/VegaLite/SchemeParams.ts
+++ b/packages/encodable/src/types/VegaLite/SchemeParams.ts
@@ -1,0 +1,18 @@
+export interface SchemeParams {
+  /**
+   * A color scheme name for ordinal scales (e.g., `"category10"` or `"blues"`).
+   *
+   * For the full list of supported schemes, please refer to the [Vega Scheme](https://vega.github.io/vega/docs/schemes/#reference) reference.
+   */
+  name: string;
+
+  /**
+   * The extent of the color range to use. For example `[0.2, 1]` will rescale the color scheme such that color values in the range _[0, 0.2)_ are excluded from the scheme.
+   */
+  extent?: number[];
+
+  /**
+   * The number of colors to use in the scheme. This can be useful for scale types such as `"quantize"`, which use the length of the scale range to determine the number of discrete bins for the scale domain.
+   */
+  count?: number;
+}

--- a/packages/encodable/src/types/VegaLite/index.ts
+++ b/packages/encodable/src/types/VegaLite/index.ts
@@ -1,0 +1,25 @@
+// Types imported from vega-lite
+export { SchemeParams, Scale, NiceTime } from 'vega-lite/build/src/scale';
+export { Axis } from 'vega-lite/build/src/axis';
+
+// Same with vega-lite version
+/** Possible values */
+export type Value = number | string | boolean | null;
+
+// Override and exclude gradient type
+/**
+ * Definition object for a constant value of an encoding channel.
+ */
+export interface ValueDef<V extends Value | Value[] = Value> {
+  /**
+   * A constant value in visual domain (e.g., `"red"` / `"#0099ff"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity).
+   */
+  value: V;
+}
+
+// Override and exclude geojson type
+/** field type */
+export type Type = 'quantitative' | 'ordinal' | 'temporal' | 'nominal';
+
+export { DateTime } from './DateTime';
+export { ScaleType } from './ScaleType';

--- a/packages/encodable/src/types/VegaLite/index.ts
+++ b/packages/encodable/src/types/VegaLite/index.ts
@@ -1,12 +1,8 @@
-// Types imported from vega-lite
-export { SchemeParams, Scale, NiceTime } from 'vega-lite/build/src/scale';
-export { Axis } from 'vega-lite/build/src/axis';
-
 // Same with vega-lite version
 /** Possible values */
 export type Value = number | string | boolean | null;
 
-// Override and exclude gradient type
+// Override: exclude gradient type
 /**
  * Definition object for a constant value of an encoding channel.
  */
@@ -17,9 +13,13 @@ export interface ValueDef<V extends Value | Value[] = Value> {
   value: V;
 }
 
-// Override and exclude geojson type
+// Override: exclude geojson type
 /** field type */
 export type Type = 'quantitative' | 'ordinal' | 'temporal' | 'nominal';
 
-export { DateTime } from './DateTime';
-export { ScaleType } from './ScaleType';
+export * from './Axis';
+export * from './DateTime';
+export * from './Mixins';
+export * from './Scale';
+export * from './ScaleType';
+export * from './SchemeParams';

--- a/packages/encodable/src/utils/keys.ts
+++ b/packages/encodable/src/utils/keys.ts
@@ -1,0 +1,7 @@
+/**
+ * This is a stricter version of Object.keys but with better types.
+ * See https://github.com/Microsoft/TypeScript/pull/12253#issuecomment-263132208
+ */
+const keys = Object.keys as <T>(o: T) => Extract<keyof T, string>[];
+
+export default keys;

--- a/packages/encodable/test/fillers/completeScaleConfig.test.ts
+++ b/packages/encodable/test/fillers/completeScaleConfig.test.ts
@@ -115,6 +115,7 @@ describe('completeScaleConfig(channelDef)', () => {
     ).toEqual(false);
   });
   it('returns false if cannot infer scale type', () => {
+    // @ts-expect-error
     expect(completeScaleConfig('X', { type: 'geojson', field: 'lat' })).toEqual(false);
   });
 });

--- a/packages/encodable/test/parsers/dateTimeToTimestamp.test.ts
+++ b/packages/encodable/test/parsers/dateTimeToTimestamp.test.ts
@@ -1,0 +1,45 @@
+import dateTimeToTimestamp from '../../src/parsers/dateTimeToTimestamp';
+import { DateTime } from '../../lib';
+
+describe('dateTimeToTimestamp()', () => {
+  it('should return date as timestamp if specified with month number', () => {
+    const d: DateTime = {
+      year: 1970,
+      month: 1, // January
+      date: 1,
+    };
+    const expr = dateTimeToTimestamp(d);
+    expect(expr).toBe(Number(new Date(1970, 0, 1, 0, 0, 0, 0)));
+  });
+
+  it('should return date as timestamp if specified with month name', () => {
+    const d: DateTime = {
+      year: 1970,
+      month: 'January',
+      date: 1,
+    };
+    const expr = dateTimeToTimestamp(d);
+    expect(expr).toBe(Number(new Date(1970, 0, 1, 0, 0, 0, 0)));
+  });
+
+  it('should use UTC if specified', () => {
+    const d: DateTime = {
+      year: 2007,
+      date: 1,
+      utc: true,
+    };
+    const exprJSON = dateTimeToTimestamp(d);
+    expect(exprJSON).toBe(Number(new Date(Date.UTC(2007, 0, 1, 0, 0, 0, 0))));
+  });
+
+  it('should support accidental use of strings', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const d: any = {
+      year: '2007',
+      month: '1',
+      date: '1',
+    };
+    const exprJSON = dateTimeToTimestamp(d);
+    expect(exprJSON).toBe(Number(new Date(2007, 0, 1, 0, 0, 0, 0)));
+  });
+});

--- a/packages/encodable/test/parsers/dateTimeToTimestamp.test.ts
+++ b/packages/encodable/test/parsers/dateTimeToTimestamp.test.ts
@@ -1,7 +1,195 @@
-import dateTimeToTimestamp from '../../src/parsers/dateTimeToTimestamp';
+import mockConsole, { RestoreConsole } from 'jest-mock-console';
+import dateTimeToTimestamp, {
+  normalizeQuarter,
+  normalizeDay,
+  normalizeMonth,
+  dateTimeParts,
+} from '../../src/parsers/dateTimeToTimestamp';
 import { DateTime } from '../../lib';
 
 describe('dateTimeToTimestamp()', () => {
+  let restoreConsole: RestoreConsole;
+
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    restoreConsole = mockConsole();
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    restoreConsole();
+  });
+
+  describe('normalizeQuarter(q)', () => {
+    it('returns normalized quarter (0-based)', () => {
+      expect(normalizeQuarter(3)).toEqual(2);
+      expect(normalizeQuarter('4')).toEqual(3);
+    });
+    it('warns if quarter is more than 4', () => {
+      normalizeQuarter('5');
+      expect(console.warn).toHaveBeenCalled();
+    });
+    it('throws invalid quarter', () => {
+      expect(() => normalizeQuarter('haha')).toThrow('Invalid quarter: haha');
+    });
+  });
+
+  describe('normalizeMonth(m)', () => {
+    it('returns normalized month (0-based)', () => {
+      expect(normalizeMonth(3)).toEqual(2);
+      expect(normalizeMonth('4')).toEqual(3);
+    });
+    it('returns normalized month from string', () => {
+      expect(normalizeMonth('march')).toEqual(2);
+      expect(normalizeMonth('mar')).toEqual(2);
+    });
+    it('throws invalid quarter', () => {
+      expect(() => normalizeMonth('haha')).toThrow('Invalid month: haha');
+    });
+  });
+
+  describe('normalizeDay(m)', () => {
+    it('returns normalized day of week', () => {
+      expect(normalizeDay(3)).toEqual(3);
+      expect(normalizeDay('4')).toEqual(4);
+      expect(normalizeDay(14)).toEqual(0);
+    });
+    it('returns normalized day from string', () => {
+      expect(normalizeDay('sunday')).toEqual(0);
+      expect(normalizeDay('sun')).toEqual(0);
+      expect(normalizeDay('tuesday')).toEqual(2);
+      expect(normalizeDay('tue')).toEqual(2);
+    });
+    it('throws invalid quarter', () => {
+      expect(() => normalizeDay('haha')).toThrow('Invalid day: haha');
+    });
+  });
+
+  describe('dateTimeParts(d, normalize)', () => {
+    describe('normalize=true', () => {
+      it('ignores day if other fields are present', () => {
+        expect(
+          dateTimeParts(
+            {
+              year: 1970,
+              month: 1, // January
+              date: 1,
+              day: 3,
+            },
+            true,
+          ),
+        ).toEqual([1970, 0, 1, 0, 0, 0, 0]);
+      });
+
+      it('sets year to 0 by default', () => {
+        expect(
+          dateTimeParts(
+            {
+              month: 1, // January
+              date: 1,
+            },
+            true,
+          ),
+        ).toEqual([0, 0, 1, 0, 0, 0, 0]);
+      });
+
+      it('sets year to 2006 if only day is specified', () => {
+        expect(
+          dateTimeParts(
+            {
+              day: 3,
+            },
+            true,
+          ),
+        ).toEqual([2006, 0, 4, 0, 0, 0, 0]);
+      });
+
+      it('converts quarter to month', () => {
+        expect(
+          dateTimeParts(
+            {
+              year: 2001,
+              quarter: 3,
+            },
+            true,
+          ),
+        ).toEqual([2001, 6, 1, 0, 0, 0, 0]);
+      });
+
+      it('passes hours, minutes, seconds, and milliseconds', () => {
+        expect(
+          dateTimeParts(
+            {
+              year: 2001,
+              month: 3,
+              date: 1,
+              hours: 2,
+              minutes: 3,
+              seconds: 4,
+              milliseconds: 5,
+            },
+            true,
+          ),
+        ).toEqual([2001, 2, 1, 2, 3, 4, 5]);
+      });
+    });
+    describe('normalize=false', () => {
+      it('does not normalize month', () => {
+        expect(
+          dateTimeParts(
+            {
+              year: 2000,
+              month: 3,
+            },
+            false,
+          ),
+        ).toEqual([2000, 3, 1, 0, 0, 0, 0]);
+      });
+      it('does not normalize quarter', () => {
+        expect(
+          dateTimeParts(
+            {
+              year: 2000,
+              quarter: 4,
+            },
+            false,
+          ),
+        ).toEqual([2000, 12, 1, 0, 0, 0, 0]);
+      });
+      it('does not normalize day', () => {
+        expect(
+          dateTimeParts(
+            {
+              day: 5,
+            },
+            false,
+          ),
+        ).toEqual([2006, 0, 6, 0, 0, 0, 0]);
+      });
+      it('does not change quarter string to number', () => {
+        expect(
+          dateTimeParts(
+            {
+              year: '2001',
+              quarter: '3',
+            },
+            false,
+          ),
+        ).toEqual(['2001', '3*3', 1, 0, 0, 0, 0]);
+      });
+      it('does not change day string to number', () => {
+        expect(
+          dateTimeParts(
+            {
+              day: '5',
+            },
+            false,
+          ),
+        ).toEqual([2006, 0, '5+1', 0, 0, 0, 0]);
+      });
+    });
+  });
+
   it('should return date as timestamp if specified with month number', () => {
     const d: DateTime = {
       year: 1970,

--- a/packages/encodable/test/typeGuards/DateTime.test.ts
+++ b/packages/encodable/test/typeGuards/DateTime.test.ts
@@ -1,0 +1,29 @@
+import { isDateTime } from '../../src/typeGuards/DateTime';
+
+describe('type guards: DateTime', () => {
+  describe('isDateTime', () => {
+    it('correctly classifies non-DateTime types', () => {
+      expect(isDateTime(true)).toEqual(false);
+      expect(isDateTime(false)).toEqual(false);
+      expect(isDateTime(0)).toEqual(false);
+      expect(isDateTime(1)).toEqual(false);
+      expect(isDateTime('abcdef')).toEqual(false);
+    });
+
+    it('correctly classifies DateTime object', () => {
+      expect(isDateTime({ year: 1986 })).toEqual(true);
+      expect(isDateTime({ quarter: 2 })).toEqual(true);
+      expect(isDateTime({ month: 5 })).toEqual(true);
+      expect(isDateTime({ date: 15 })).toEqual(true);
+      expect(isDateTime({ day: 1 })).toEqual(true);
+      expect(isDateTime({ hours: 6 })).toEqual(true);
+      expect(isDateTime({ minutes: 16 })).toEqual(true);
+      expect(isDateTime({ seconds: 59 })).toEqual(true);
+      expect(isDateTime({ milliseconds: 106 })).toEqual(true);
+    });
+
+    it('correctly classifies unit with zero', () => {
+      expect(isDateTime({ hours: 0 })).toEqual(true);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7135,6 +7135,11 @@ jest-message-util@^25.5.0:
     slash "^3.0.0"
     stack-utils "^1.0.1"
 
+jest-mock-console@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jest-mock-console/-/jest-mock-console-1.0.1.tgz#07978047735a782d0d4172d1afcabd82f6de9b08"
+  integrity sha512-Bn+Of/cvz9LOEEeEg5IX5Lsf8D2BscXa3Zl5+vSVJl37yiT8gMAPPKfE09jJOwwu1zbagL11QTrH+L/Gn8udOg==
+
 jest-mock@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-25.5.0.tgz#a91a54dabd14e37ecd61665d6b6e06360a55387a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2632,11 +2632,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/clone@~0.1.30":
-  version "0.1.30"
-  resolved "https://registry.yarnpkg.com/@types/clone/-/clone-0.1.30.tgz#e7365648c1b42136a59c7d5040637b3b5c83b614"
-  integrity sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=
-
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -2703,11 +2698,6 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
-
-"@types/fast-json-stable-stringify@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#40363bb847cb86b2c2e1599f1398d11e8329c921"
-  integrity sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ==
 
 "@types/glob@^7.1.1":
   version "7.1.1"
@@ -3182,11 +3172,6 @@ array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
   integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
-
-array-flat-polyfill@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz#1e3a4255be619dfbffbfd1d635c1cf357cd034e7"
-  integrity sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw==
 
 array-ify@^1.0.0:
   version "1.0.0"
@@ -3954,11 +3939,6 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-clone@~2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
-
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -4021,7 +4001,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2, commander@^2.11.0, commander@^2.19.0, commander@~2.20.3:
+commander@^2.11.0, commander@^2.19.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -4501,77 +4481,20 @@ cz-conventional-changelog@2.1.0, cz-conventional-changelog@^2.1.0:
     right-pad "^1.0.1"
     word-wrap "^1.0.3"
 
-d3-array@1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
-  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
-
-"d3-array@1.2.0 - 2", d3-array@^2.3.1, d3-array@^2.4.0:
+"d3-array@1.2.0 - 2", d3-array@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
   integrity sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw==
 
-d3-color@1, d3-color@^1.4.1:
+d3-color@1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
   integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
 
-d3-delaunay@^5.2.1:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-5.3.0.tgz#b47f05c38f854a4e7b3cea80e0bb12e57398772d"
-  integrity sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==
-  dependencies:
-    delaunator "4"
-
-d3-dispatch@1:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.6.tgz#00d37bcee4dd8cd97729dd893a0ac29caaba5d58"
-  integrity sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==
-
-d3-dsv@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.2.0.tgz#9d5f75c3a5f8abd611f74d3f5847b0d4338b885c"
-  integrity sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==
-  dependencies:
-    commander "2"
-    iconv-lite "0.4"
-    rw "1"
-
-d3-force@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-2.0.1.tgz#31750eee8c43535301d571195bf9683beda534e2"
-  integrity sha512-zh73/N6+MElRojiUG7vmn+3vltaKon7iD5vB/7r9nUaBeftXMzRo5IWEG63DLBCto4/8vr9i3m9lwr1OTJNiCg==
-  dependencies:
-    d3-dispatch "1"
-    d3-quadtree "1"
-    d3-timer "1"
-
-d3-format@1, d3-format@^1.3.2, d3-format@^1.4.4:
+d3-format@1, d3-format@^1.3.2:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.4.tgz#356925f28d0fd7c7983bfad593726fce46844030"
   integrity sha512-TWks25e7t8/cqctxCmxpUuzZN11QxIA7YrMbram94zMQ0PXjE4LVIMe/f6a4+xxL8HQ3OsAFULOINQi1pE62Aw==
-
-d3-geo-projection@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/d3-geo-projection/-/d3-geo-projection-2.9.0.tgz#826db62f748e8ecd67cd00aced4c26a236ec030c"
-  integrity sha512-ZULvK/zBn87of5rWAfFMc9mJOipeSo57O+BBitsKIXmU4rTVAnX1kSsJkE0R+TxY8pGNoM1nbyRRE7GYHhdOEQ==
-  dependencies:
-    commander "2"
-    d3-array "1"
-    d3-geo "^1.12.0"
-    resolve "^1.1.10"
-
-d3-geo@^1.12.0:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.12.1.tgz#7fc2ab7414b72e59fbcbd603e80d9adc029b035f"
-  integrity sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==
-  dependencies:
-    d3-array "1"
-
-d3-hierarchy@^1.1.9:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz#2f6bee24caaea43f8dc37545fa01628559647a83"
-  integrity sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==
 
 d3-interpolate@^1.2.0, d3-interpolate@^1.3.2, d3-interpolate@^1.4.0:
   version "1.4.0"
@@ -4580,17 +4503,7 @@ d3-interpolate@^1.2.0, d3-interpolate@^1.3.2, d3-interpolate@^1.4.0:
   dependencies:
     d3-color "1"
 
-d3-path@1, d3-path@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
-  integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
-
-d3-quadtree@1:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.7.tgz#ca8b84df7bb53763fe3c2f24bd435137f4e53135"
-  integrity sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==
-
-d3-scale@^3.0.0, d3-scale@^3.0.1, d3-scale@^3.2.1:
+d3-scale@^3.0.0, d3-scale@^3.0.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-3.2.1.tgz#da1684adce7261b4bc7a76fe193d887f0e909e69"
   integrity sha512-huz5byJO/6MPpz6Q8d4lg7GgSpTjIZW/l+1MQkzKfu2u8P6hjaXaStOpmyrD6ymKoW87d2QVFCKvSjLwjzx/rA==
@@ -4601,29 +4514,17 @@ d3-scale@^3.0.0, d3-scale@^3.0.1, d3-scale@^3.2.1:
     d3-time "1"
     d3-time-format "2"
 
-d3-shape@^1.3.7:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
-  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
-  dependencies:
-    d3-path "1"
-
-d3-time-format@2, d3-time-format@^2.2.0, d3-time-format@^2.2.3:
+d3-time-format@2, d3-time-format@^2.2.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.2.3.tgz#0c9a12ee28342b2037e5ea1cf0b9eb4dd75f29cb"
   integrity sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==
   dependencies:
     d3-time "1"
 
-d3-time@1, d3-time@^1.0.10, d3-time@^1.0.11, d3-time@^1.1.0:
+d3-time@1, d3-time@^1.0.10, d3-time@^1.0.11:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
   integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
-
-d3-timer@1, d3-timer@^1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
-  integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
 
 damerau-levenshtein@^1.0.4:
   version "1.0.6"
@@ -4759,11 +4660,6 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
-
-delaunator@4:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-4.0.1.tgz#3d779687f57919a7a418f8ab947d3bddb6846957"
-  integrity sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -5604,7 +5500,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^3.1.1, fast-deep-equal@~3.1.1:
+fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
@@ -5638,7 +5534,7 @@ fast-glob@^3.0.4, fast-glob@^3.1.1, fast-glob@^3.2.2:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@~2.1.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -6429,7 +6325,7 @@ i18next@^19.4.2:
   dependencies:
     "@babel/runtime" "^7.3.1"
 
-iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -7497,11 +7393,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stringify-pretty-compact@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz#e77c419f52ff00c45a31f07f4c820c2433143885"
-  integrity sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==
-
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -8361,7 +8252,7 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0:
+node-fetch@^2.3.0, node-fetch@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
@@ -9802,7 +9693,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.x, resolve@^1.1.10, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1:
+resolve@1.x, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -9895,11 +9786,6 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
-
-rw@1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
-  integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
 
 rxjs@^6.1.0, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.5.5:
   version "6.5.5"
@@ -10814,13 +10700,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-topojson-client@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/topojson-client/-/topojson-client-3.1.0.tgz#22e8b1ed08a2b922feeb4af6f53b6ef09a467b99"
-  integrity sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==
-  dependencies:
-    commander "2"
-
 tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
@@ -10885,11 +10764,6 @@ tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
-
-tslib@~1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tsutils@^3.17.1:
   version "3.17.1"
@@ -11144,336 +11018,6 @@ validate-npm-package-name@^3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
-
-vega-canvas@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/vega-canvas/-/vega-canvas-1.2.2.tgz#f31aae9ac1e1ed01bb7817a1e53099279e2d3d43"
-  integrity sha512-39h8/fZp4kDwSeDGIEoyEiIgtP3mgY3D08InD1Ldm0FntePpSe1tXzC1zcvoLe/+f7Qprl6Jfwux/ksOXvpj2w==
-
-vega-crossfilter@~4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/vega-crossfilter/-/vega-crossfilter-4.0.2.tgz#739a26eb8eb741b3e1725679d09ee2af56f983b5"
-  integrity sha512-wlKpqBEUpDd/Y3aaC1u91lebXR+sS7LElYv2jGDDG5pA+RS8lRo3NmSClKVBM5NcY80IeMywG+0a/ogzVeBrPQ==
-  dependencies:
-    d3-array "^2.4.0"
-    vega-dataflow "^5.5.1"
-    vega-util "^1.13.2"
-
-vega-dataflow@^5.5.1, vega-dataflow@^5.6.0, vega-dataflow@~5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/vega-dataflow/-/vega-dataflow-5.6.0.tgz#7fd3d9f691deaafafe3cb74b2e6bb0c9dfeb6e16"
-  integrity sha512-Vl1gQptJQzjACprXwelSxG0E+uc7iU3eYzdxafZWs1Jl0cHeMlviawVHOsaCofOo6UXpFiuP9DkXh1kzE7mnrQ==
-  dependencies:
-    vega-format "^1.0.0"
-    vega-loader "^4.3.0"
-    vega-util "^1.14.0"
-
-vega-encode@~4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/vega-encode/-/vega-encode-4.7.0.tgz#d38e99ce35dd72abfa16a70002f1a29f4af3113a"
-  integrity sha512-s36E5tEaN7YIVf8ial3U7oDscr+lLLirrtvsIBZaofPVuT/9m6NKxjKr9pk9TCqsGB5WmqwIkCw4+VwKW+dHlQ==
-  dependencies:
-    d3-array "^2.4.0"
-    d3-interpolate "^1.4.0"
-    vega-dataflow "^5.6.0"
-    vega-scale "^7.0.0"
-    vega-util "^1.14.0"
-
-vega-event-selector@^2.0.3, vega-event-selector@~2.0.2, vega-event-selector@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/vega-event-selector/-/vega-event-selector-2.0.3.tgz#760c61af7ab5c325d3274fd3ab284d067ff16f8c"
-  integrity sha512-rUnAvBSy5tkk+0MELY7qICTgjMNjH/DDNIH603q3GRi+bBRCd4MlJxWrPYBhwZIYpmr6XCe130lZ90/F5SgVfA==
-
-vega-expression@^2.6.4, vega-expression@^2.6.5, vega-expression@~2.6.3, vega-expression@~2.6.5:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/vega-expression/-/vega-expression-2.6.5.tgz#7bda7524b9223cbbf9034071695c7c2a9bd81971"
-  integrity sha512-3hJts0gKomu3ePXYeIb+VAw7yNKoHJ6VqSKsHHFPyoEGNdwmlgI5d9IBblelPCiMCHK4sMt7h1OTWB33cfxZGA==
-  dependencies:
-    vega-util "^1.14.0"
-
-vega-force@~4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/vega-force/-/vega-force-4.0.4.tgz#b73cba2e169cc248c994c9d981c374eb06aff764"
-  integrity sha512-ETTezb3lpQIbrk8pdmv4WpoNlChWdIK1Hv5CHL8Q/oOT/lIop/NHnI+JZO4yuzaYv+o3UqNWPcjiY0U5/i51dw==
-  dependencies:
-    d3-force "^2.0.1"
-    vega-dataflow "^5.5.1"
-    vega-util "^1.13.2"
-
-vega-format@^1.0.0, vega-format@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/vega-format/-/vega-format-1.0.1.tgz#94b5be9eb3d6a8b315fcf3d523ed6a1bb2ea4d71"
-  integrity sha512-f9IZ+SDHVFFneDDc+d8RfeJhXXvUgquAuM+1MZ2Rjf4xqpg+E8FSNQkh8wjeo82mc6G3KVa9hynSdfN/a0AktQ==
-  dependencies:
-    d3-array "^2.4.0"
-    d3-format "^1.4.4"
-    d3-time-format "^2.2.3"
-    vega-time "^2.0.0"
-    vega-util "^1.14.0"
-
-vega-functions@^5.7.0, vega-functions@~5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/vega-functions/-/vega-functions-5.7.0.tgz#07cb29d9f0c2a65497edbb0c4e064b31b9e78cb4"
-  integrity sha512-Ea8pFE0BiPrsSxnFSenOI4oanoitoJcPS+P81JdJM3Bgd8DkyiGaoN3484PDhzk4WWVleopyG0LhId25SlsSEA==
-  dependencies:
-    d3-array "^2.4.0"
-    d3-color "^1.4.1"
-    d3-geo "^1.12.0"
-    vega-dataflow "^5.6.0"
-    vega-expression "^2.6.5"
-    vega-scale "^7.0.0"
-    vega-scenegraph "^4.8.0"
-    vega-selections "^5.1.1"
-    vega-statistics "^1.7.5"
-    vega-time "^2.0.0"
-    vega-util "^1.14.0"
-
-vega-geo@~4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/vega-geo/-/vega-geo-4.3.3.tgz#7fe9cb7855c829cf2ac551b2a895345568faf41c"
-  integrity sha512-Cu8trg9Mwk22eXi+DxWkcPOELXfBQlAwFV648B9PPzzqJc9oPCVV7C76dzKh5zb73IfymcsS6rRcdKOLeWyrZg==
-  dependencies:
-    d3-array "^2.4.0"
-    d3-color "^1.4.1"
-    d3-geo "^1.12.0"
-    vega-canvas "^1.2.2"
-    vega-dataflow "^5.6.0"
-    vega-projection "^1.4.1"
-    vega-statistics "^1.7.5"
-    vega-util "^1.14.0"
-
-vega-hierarchy@~4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/vega-hierarchy/-/vega-hierarchy-4.0.6.tgz#e286e917e47f1d4d9bfefa278cfdfa163d9f1225"
-  integrity sha512-v71NQzz9503aBJgRPnrBEZ/87q58EjwylmAs3uh+SaI5ocMCn9+goE+x5ZwZ0gNT9qJv4Umm5L3GZ9h8LuXjlg==
-  dependencies:
-    d3-hierarchy "^1.1.9"
-    vega-dataflow "^5.5.1"
-    vega-util "^1.13.2"
-
-vega-lite@~4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-4.1.1.tgz#f6e6cae4e0518c66afd0298fb544b6a35290437b"
-  integrity sha512-D2seO6ZbY8aZQ8+ZQfU+5NYwot3ryIDyvdQdcVoupMSgJ/oGv4QqEwL3rmu8abdSG6NhFiac0trsI+wBb0F6vQ==
-  dependencies:
-    "@types/clone" "~0.1.30"
-    "@types/fast-json-stable-stringify" "^2.0.0"
-    array-flat-polyfill "^1.0.1"
-    clone "~2.1.2"
-    fast-deep-equal "~3.1.1"
-    fast-json-stable-stringify "~2.1.0"
-    json-stringify-pretty-compact "~2.0.0"
-    tslib "~1.10.0"
-    vega-event-selector "~2.0.2"
-    vega-expression "~2.6.3"
-    vega-typings "~0.12.0"
-    vega-util "~1.12.2"
-    yargs "~15.1.0"
-
-vega-loader@^4.3.0, vega-loader@~4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/vega-loader/-/vega-loader-4.3.0.tgz#f32d70e2dd57d753e4160aae2e1f48c20e0d00e5"
-  integrity sha512-XrwwJ1xWnsVS2N2M4vdvzieUdXWegdD31t04sCPQ5C3US58NYlq1ho1Md+5FVrtl0uCd0wG/mk700Jp7yPhN+w==
-  dependencies:
-    d3-dsv "^1.2.0"
-    node-fetch "^2.6.0"
-    topojson-client "^3.1.0"
-    vega-format "^1.0.0"
-    vega-util "^1.14.0"
-
-vega-parser@~6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-6.0.2.tgz#c76dfd13a38abedacb07658fe75fd0c05a509a1c"
-  integrity sha512-3337WvsUuuYZ0+H7ew4uZFgn82QWoaWv/9uinlMOH7ncnu8qTuWt4nV3WoUX9RFqie38qIMw/mf6+HK5gfXBoQ==
-  dependencies:
-    vega-dataflow "^5.6.0"
-    vega-event-selector "^2.0.3"
-    vega-functions "^5.7.0"
-    vega-scale "^7.0.0"
-    vega-util "^1.14.0"
-
-vega-projection@^1.4.1, vega-projection@~1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/vega-projection/-/vega-projection-1.4.1.tgz#653f8def85c0440669e6700b9126fe70bac2da9e"
-  integrity sha512-6Rfv/6gqhuEjWGoti9YNqCYLWXb3st+bytqIyiYMmTS8nEQLhH8UyOHwbq5eYOCT4Sn7Q4nsLz+i2I5vgIfUAw==
-  dependencies:
-    d3-geo "^1.12.0"
-    d3-geo-projection "^2.9.0"
-
-vega-regression@~1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/vega-regression/-/vega-regression-1.0.6.tgz#0081a91328e933c826813c06afe7041915532d4f"
-  integrity sha512-s4kjsKp23WvDJDHkpIrGNUaLI3/95k6nTURj9RDtM4C6CbUgO2snIaEfki4JfOCnBYtvotwDuZgXKmJInu9hVw==
-  dependencies:
-    d3-array "^2.4.0"
-    vega-dataflow "^5.5.1"
-    vega-statistics "^1.7.4"
-    vega-util "^1.13.2"
-
-vega-runtime@^6.0.0, vega-runtime@~6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/vega-runtime/-/vega-runtime-6.0.0.tgz#f2fb9d0f36fd65455b6ff112813125ae4aa8b5d3"
-  integrity sha512-lAHeIrzEhM3Nwwrjen4nG+a4UwG8B8U2wzMweXByVGGovv2PkDt2U3AzR036uUuM388byZg08I/FdgUgYOvYPg==
-  dependencies:
-    vega-dataflow "^5.6.0"
-    vega-util "^1.14.0"
-
-vega-scale@^7.0.0, vega-scale@~7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/vega-scale/-/vega-scale-7.0.0.tgz#0101802c6da29e2e903887160a269d57d6da479e"
-  integrity sha512-3oQAQYLRk+PIs6aF6kdb7tbhm5IpxNiwdFVM9fNS+SSsii6v8kFC681EuUMqLVZOHELiklWIE1rZIHaB5dNRXg==
-  dependencies:
-    d3-array "^2.4.0"
-    d3-interpolate "^1.4.0"
-    d3-scale "^3.2.1"
-    vega-time "^2.0.0"
-    vega-util "^1.14.0"
-
-vega-scenegraph@^4.8.0, vega-scenegraph@^4.8.1, vega-scenegraph@~4.8.3:
-  version "4.8.3"
-  resolved "https://registry.yarnpkg.com/vega-scenegraph/-/vega-scenegraph-4.8.3.tgz#11b557019175ec5ddc258c3a5eb7371e64cec5e1"
-  integrity sha512-2GznqXm/py7/XX9juohFbLYQTKxHY5VNRZLHc0bL35Nd7lShKeOlHY9uVkHw2FoLLCz78UcXFminWM8lddvGxw==
-  dependencies:
-    d3-path "^1.0.9"
-    d3-shape "^1.3.7"
-    vega-canvas "^1.2.2"
-    vega-loader "^4.3.0"
-    vega-scale "^7.0.0"
-    vega-util "^1.14.0"
-
-vega-selections@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/vega-selections/-/vega-selections-5.1.1.tgz#5ea3931bbf7bc13f2ab7c5c5ebf39aed98e4c114"
-  integrity sha512-ztZUMfDicuIGJHZimSdVvMGzMvaa37ICzUHHvwxS51OhYv096dzKgoSypjx+tsmR7wnhY7ZL+iQgpT1/O29jlA==
-  dependencies:
-    vega-expression "^2.6.4"
-    vega-util "^1.13.2"
-
-vega-statistics@^1.7.4, vega-statistics@^1.7.5, vega-statistics@~1.7.5:
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/vega-statistics/-/vega-statistics-1.7.5.tgz#da57461f95be942c93f86644631da46bc0e9bea0"
-  integrity sha512-6yj2V8l7rU123RIvXKiXDMC6ZCJOuToeZcqzTv4VZCRBXilVQeYzam9/nhIVROzh+4KtRW1I5oayMQqrHzIIfw==
-  dependencies:
-    d3-array "^2.4.0"
-
-vega-time@^2.0.0, vega-time@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/vega-time/-/vega-time-2.0.1.tgz#2a91c3acafd091e6724063dea26e4b3fe6061d2f"
-  integrity sha512-Ij0gmABKDRKAMUTh/1AGSSkU6ocWiteLkIK/cmcnt98u8LiuVcFT5w7gusd0+ibO9EooeMKazn5xPmjvQs0qEg==
-  dependencies:
-    d3-array "^2.4.0"
-    d3-time "^1.1.0"
-    vega-util "^1.14.0"
-
-vega-transforms@~4.8.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/vega-transforms/-/vega-transforms-4.8.2.tgz#1f175a0c912311c2ec1b50ed35ca5f69c116d2bd"
-  integrity sha512-hN0FMkmkq+EkN7TJVF29O7UThiOEbfMpsYWaUeQ1Us+1inkX0/xrwmfKflMGHbbTMUahg/OFGHSYFKYZhTuMaA==
-  dependencies:
-    d3-array "^2.4.0"
-    vega-dataflow "^5.6.0"
-    vega-statistics "^1.7.5"
-    vega-time "^2.0.0"
-    vega-util "^1.14.0"
-
-vega-typings@~0.12.0:
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/vega-typings/-/vega-typings-0.12.4.tgz#e3b298723db1a484aae6ca1cf760ff20fd46fae1"
-  integrity sha512-2tnAfFMxaGul1875q6v6vZW20s+j9hYGlt/lpp3yVYYGARG7hjgwyHpOKnHzw3C/huy4JaHaMhf3psXgG/VnHw==
-  dependencies:
-    vega-util "^1.12.1"
-
-vega-typings@~0.17.2:
-  version "0.17.2"
-  resolved "https://registry.yarnpkg.com/vega-typings/-/vega-typings-0.17.2.tgz#55b1f6f9778ec9a5f642748579a402a67f3985ae"
-  integrity sha512-p/JcMIxcs5BtV2BaWJOCqVm4YEcxPZzlvXbhtoLFprdeIyKpRPvdoq3EJdDH/HtEn9jxs3GVR5Myfw5epqCp0w==
-  dependencies:
-    vega-util "^1.14.0"
-
-vega-util@^1.12.1, vega-util@^1.13.2, vega-util@^1.14.0, vega-util@~1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.14.0.tgz#56180bf09c28acc2b4c17c38e16d6673f45d9331"
-  integrity sha512-j7Gdeasf9C4yUgjlTFJ8P5RpV6n5UxFRzxWkNx4tbMir6f7YM6vGd7vzGWgFdJ3oJy/cmXHzNZw5lw4gnjQAog==
-
-vega-util@~1.12.2:
-  version "1.12.2"
-  resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.12.2.tgz#4997a50e56fa4be05046966568aed72246a40e27"
-  integrity sha512-p02+oQ/XU/gzY9S/CTZinym2NKWEMIneLc+FYdUeJZZnDGa3DvcNgUDlVR90JlwLcYZNs5dBdfYLfdRHsKZKiw==
-
-vega-view-transforms@~4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/vega-view-transforms/-/vega-view-transforms-4.5.5.tgz#b934da0fc1b41c10039300c036cfa38a56c83631"
-  integrity sha512-HFTA6j2zFKRlfBlS6b9tmLLDNt7g78ZoyKFAT9fCm3X0KLT6FTn13PiiB4KppMg40nwgm0c2KUQmjnC6fGgIdQ==
-  dependencies:
-    vega-dataflow "^5.6.0"
-    vega-scenegraph "^4.8.0"
-    vega-util "^1.14.0"
-
-vega-view@~5.7.1:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/vega-view/-/vega-view-5.7.1.tgz#d0b1012c2e58921062c3139d14dc23efb28b832b"
-  integrity sha512-oL86Uc0grKrOjSfW4W64QFKjtaCqUGfPzzryLIbXXx6ts3luHaQ3lF1MnmOMR5ddak5R29Mt0607W3GXqHnmZw==
-  dependencies:
-    d3-array "^2.4.0"
-    d3-timer "^1.0.10"
-    vega-dataflow "^5.6.0"
-    vega-format "^1.0.0"
-    vega-functions "^5.7.0"
-    vega-runtime "^6.0.0"
-    vega-scenegraph "^4.8.1"
-    vega-util "^1.14.0"
-
-vega-voronoi@~4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/vega-voronoi/-/vega-voronoi-4.1.2.tgz#459b78f5191fb707e94d9afa7d8c1a68ad9aec7a"
-  integrity sha512-XXp2UChi4/6jkEqWkLFbjDBVLMizQICWDv4RUkfMeDNhWmhEY/3kPHCU6taqfTVkbxfA7aN20ivbakJzoywiAQ==
-  dependencies:
-    d3-delaunay "^5.2.1"
-    vega-dataflow "^5.5.1"
-    vega-util "^1.13.2"
-
-vega-wordcloud@~4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/vega-wordcloud/-/vega-wordcloud-4.1.0.tgz#edf020a99378eb88109cb9ac4702fec0e0ac8cdd"
-  integrity sha512-WiISiNlHdbTL6QsnxyzxbniUgcPmjzwdwZzu6clQSHXNRz9kThCPhXOyLwYdbFV+9sjd4sJlW0YOaCcx7wMT2Q==
-  dependencies:
-    vega-canvas "^1.2.2"
-    vega-dataflow "^5.6.0"
-    vega-scale "^7.0.0"
-    vega-statistics "^1.7.5"
-    vega-util "^1.14.0"
-
-vega@^5.9.1:
-  version "5.12.3"
-  resolved "https://registry.yarnpkg.com/vega/-/vega-5.12.3.tgz#9e004c0dbf653a1bb51a70f4e485956c8369a5f0"
-  integrity sha512-CBGvmNlEToOlAsXHqHROwc2Cx+cIsGK5FxR+me/+++P51yN0i4X4TWNywqNlXzpheEk7Jb3YlDSDgVRvQolRLQ==
-  dependencies:
-    vega-crossfilter "~4.0.2"
-    vega-dataflow "~5.6.0"
-    vega-encode "~4.7.0"
-    vega-event-selector "~2.0.3"
-    vega-expression "~2.6.5"
-    vega-force "~4.0.4"
-    vega-format "~1.0.1"
-    vega-functions "~5.7.0"
-    vega-geo "~4.3.3"
-    vega-hierarchy "~4.0.6"
-    vega-loader "~4.3.0"
-    vega-parser "~6.0.2"
-    vega-projection "~1.4.1"
-    vega-regression "~1.0.6"
-    vega-runtime "~6.0.0"
-    vega-scale "~7.0.0"
-    vega-scenegraph "~4.8.3"
-    vega-statistics "~1.7.5"
-    vega-time "~2.0.1"
-    vega-transforms "~4.8.2"
-    vega-typings "~0.17.2"
-    vega-util "~1.14.0"
-    vega-view "~5.7.1"
-    vega-view-transforms "~4.5.5"
-    vega-voronoi "~4.1.2"
-    vega-wordcloud "~4.1.0"
 
 verror@1.10.0:
   version "1.10.0"
@@ -11739,14 +11283,6 @@ yargs-parser@^15.0.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^16.1.0:
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.1.0.tgz#73747d53ae187e7b8dbe333f95714c76ea00ecf1"
-  integrity sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
 yargs-parser@^18.1.1, yargs-parser@^18.1.2, yargs-parser@^18.1.3:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
@@ -11788,20 +11324,3 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.1"
-
-yargs@~15.1.0:
-  version "15.1.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.1.0.tgz#e111381f5830e863a89550bd4b136bb6a5f37219"
-  integrity sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==
-  dependencies:
-    cliui "^6.0.0"
-    decamelize "^1.2.0"
-    find-up "^4.1.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^4.2.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^16.1.0"


### PR DESCRIPTION
🏠 Internal

Increase stability, reduce bundle size and build complexity by replacing imports from `vega-lite` with lean copies. 

This removes `vega` and `vega-lite` from `dependency`.