### PR TITLE
fix: fielddef formatting

### DIFF
--- a/packages/encodable/src/encoders/ChannelEncoderAxis.ts
+++ b/packages/encodable/src/encoders/ChannelEncoderAxis.ts
@@ -23,10 +23,11 @@ export default class ChannelEncoderAxis<
   constructor(channelEncoder: ChannelEncoder<Def, Output>) {
     this.channelEncoder = channelEncoder;
     this.config = channelEncoder.definition.axis as Exclude<CompleteAxisConfig, false>;
-    this.formatValue = createFormatterFromFieldTypeAndFormat(
-      (channelEncoder.definition as CompleteFieldDef<Output>).type,
-      this.config.format ?? '',
-    );
+    this.formatValue = createFormatterFromFieldTypeAndFormat({
+      type: (channelEncoder.definition as CompleteFieldDef<Output>).type,
+      format: this.config.format,
+      formatType: this.config.formatType,
+    });
   }
 
   getTitle() {

--- a/packages/encodable/src/parsers/format/createFormatterFromChannelDef.ts
+++ b/packages/encodable/src/parsers/format/createFormatterFromChannelDef.ts
@@ -1,14 +1,10 @@
 import { ChannelDef } from '../../types/ChannelDef';
-import { isTypedFieldDef } from '../../typeGuards/ChannelDef';
+import { isFieldDef } from '../../typeGuards/ChannelDef';
 import fallbackFormatter from './fallbackFormatter';
 import createFormatterFromFieldTypeAndFormat from './createFormatterFromFieldTypeAndFormat';
 
 export default function createFormatterFromChannelDef(definition: ChannelDef) {
-  if (isTypedFieldDef(definition)) {
-    const { type, format = '' } = definition;
-
-    return createFormatterFromFieldTypeAndFormat(type, format);
-  }
-
-  return fallbackFormatter;
+  return isFieldDef(definition)
+    ? createFormatterFromFieldTypeAndFormat(definition)
+    : fallbackFormatter;
 }

--- a/packages/encodable/src/parsers/format/createFormatterFromFieldTypeAndFormat.ts
+++ b/packages/encodable/src/parsers/format/createFormatterFromFieldTypeAndFormat.ts
@@ -1,19 +1,34 @@
 import { getNumberFormatter } from '@superset-ui/number-format';
 import { getTimeFormatter } from '@superset-ui/time-format';
-import { Type } from '../../types/VegaLite';
+import { Type, FormatType, FormatMixins } from '../../types/VegaLite';
 import { Formatter } from '../../types/ChannelDef';
 import fallbackFormatter from './fallbackFormatter';
 
-export default function createFormatterFromFieldTypeAndFormat(
-  type: Type,
-  format: string,
-): Formatter {
-  if (type === 'quantitative') {
+export default function createFormatterFromFieldTypeAndFormat({
+  formatType,
+  type,
+  format,
+}: FormatMixins & {
+  /** field type */
+  type?: Type;
+}): Formatter {
+  let finalType: FormatType | undefined;
+  if (typeof formatType !== 'undefined') {
+    finalType = formatType;
+  } else if (type === 'quantitative') {
+    finalType = 'number';
+  } else if (type === 'temporal') {
+    finalType = 'time';
+  } else if (typeof format !== 'undefined' && format.length > 0) {
+    finalType = 'number';
+  }
+
+  if (finalType === 'number') {
     const formatter = getNumberFormatter(format);
 
     return (value: unknown) => formatter(value as number | null | undefined);
   }
-  if (type === 'temporal') {
+  if (finalType === 'time') {
     const formatter = getTimeFormatter(format);
 
     return (value: unknown) => formatter(value as Date | number | null | undefined);

--- a/packages/encodable/src/types/Axis.ts
+++ b/packages/encodable/src/types/Axis.ts
@@ -23,6 +23,7 @@ export interface BaseAxisConfig
   extends Pick<
     VegaLiteAxis,
     | 'format'
+    | 'formatType'
     | 'labelAngle'
     | 'labelFlush'
     | 'tickCount'

--- a/packages/encodable/src/types/ChannelDef.ts
+++ b/packages/encodable/src/types/ChannelDef.ts
@@ -1,4 +1,4 @@
-import { ValueDef, Value, Type } from './VegaLite';
+import { ValueDef, Value, Type, FormatMixins } from './VegaLite';
 import { WithScale } from './Scale';
 import { WithXAxis, WithYAxis } from './Axis';
 import { WithLegend } from './Legend';
@@ -14,9 +14,8 @@ export type PropertyValue =
 
 export type Formatter = (d: unknown) => string;
 
-export interface FieldDef {
+export interface FieldDef extends FormatMixins {
   field: string;
-  format?: string;
   title?: string;
   bin?: boolean;
 }

--- a/packages/encodable/src/types/VegaLite/Mixins.ts
+++ b/packages/encodable/src/types/VegaLite/Mixins.ts
@@ -14,6 +14,8 @@ export interface TitleMixins {
   title?: string | null;
 }
 
+export type FormatType = 'number' | 'time';
+
 export interface FormatMixins {
   /**
    * The text formatting pattern for labels of guides (axes, legends, headers) and text marks.
@@ -34,12 +36,5 @@ export interface FormatMixins {
    * - `"time"` for temporal fields and ordinal and nomimal fields with `timeUnit`.
    * - `"number"` for quantitative fields as well as ordinal and nomimal fields without `timeUnit`.
    */
-  formatType?: 'number' | 'time';
-
-  /**
-   * [Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels text.
-   *
-   * __Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.
-   */
-  labelExpr?: string;
+  formatType?: FormatType;
 }

--- a/packages/encodable/test/parsers/format/createFormatterFromChannelDef.test.ts
+++ b/packages/encodable/test/parsers/format/createFormatterFromChannelDef.test.ts
@@ -1,6 +1,37 @@
 import createFormatterFromChannelDef from '../../../src/parsers/format/createFormatterFromChannelDef';
 
 describe('createFormatterFromChannelDef(type, format)', () => {
+  describe('creates formatter for FieldDef', () => {
+    it('number', () => {
+      const formatter = createFormatterFromChannelDef({
+        field: 'price',
+        formatType: 'number',
+        format: '.2f',
+      });
+      expect(formatter(5324)).toEqual('5324.00');
+    });
+    it('time', () => {
+      const formatter = createFormatterFromChannelDef({
+        field: 'lunchTime',
+        formatType: 'time',
+        format: '%b %d, %Y',
+      });
+      expect(formatter(new Date(Date.UTC(2019, 5, 20)))).toEqual('Jun 20, 2019');
+    });
+    it('format with unspecified formatType', () => {
+      const formatter = createFormatterFromChannelDef({
+        field: 'price',
+        format: '.2f',
+      });
+      expect(formatter(5324)).toEqual('5324.00');
+    });
+    it('no formatting', () => {
+      const formatter = createFormatterFromChannelDef({
+        field: 'price',
+      });
+      expect(formatter(5324)).toEqual('5324');
+    });
+  });
   it('handles when format is defined', () => {
     const formatter = createFormatterFromChannelDef({
       field: 'lunchTime',

--- a/packages/encodable/test/parsers/format/createFormatterFromFieldTypeAndFormat.test.ts
+++ b/packages/encodable/test/parsers/format/createFormatterFromFieldTypeAndFormat.test.ts
@@ -1,16 +1,46 @@
 import createFormatterFromFieldTypeAndFormat from '../../../src/parsers/format/createFormatterFromFieldTypeAndFormat';
 
 describe('createFormatterFromFieldTypeAndFormat(type, format)', () => {
-  it('handles quantitative field type', () => {
-    const formatter = createFormatterFromFieldTypeAndFormat('quantitative', '.2f');
+  it('create formatter based on formatType', () => {
+    const formatter = createFormatterFromFieldTypeAndFormat({
+      formatType: 'number',
+      format: '.2f',
+    });
     expect(formatter(200)).toEqual('200.00');
   });
-  it('handles temporal field type', () => {
-    const formatter = createFormatterFromFieldTypeAndFormat('temporal', '%b %d, %Y');
+  it('prioritize formatType over type', () => {
+    const formatter = createFormatterFromFieldTypeAndFormat({
+      formatType: 'number',
+      type: 'temporal',
+      format: '.2f',
+    });
+    expect(formatter(200)).toEqual('200.00');
+  });
+  it('uses number formatter for quantitative field type', () => {
+    const formatter = createFormatterFromFieldTypeAndFormat({
+      type: 'quantitative',
+      format: '.2f',
+    });
+    expect(formatter(200)).toEqual('200.00');
+  });
+  it('uses time formatter for temporal field type', () => {
+    const formatter = createFormatterFromFieldTypeAndFormat({
+      type: 'temporal',
+      format: '%b %d, %Y',
+    });
     expect(formatter(new Date(Date.UTC(2019, 5, 20)))).toEqual('Jun 20, 2019');
   });
+  it('uses number formatter if format is specified without format or formatType', () => {
+    const formatter = createFormatterFromFieldTypeAndFormat({
+      format: '.2f',
+    });
+    expect(formatter(200)).toEqual('200.00');
+  });
   it('uses fallback for other cases', () => {
-    const formatter = createFormatterFromFieldTypeAndFormat('nominal', '');
+    const formatter = createFormatterFromFieldTypeAndFormat({
+      type: 'nominal',
+      format: '',
+    });
     expect(formatter('cat')).toEqual('cat');
   });
 });


### PR DESCRIPTION
🐛  Bug Fix

Previously the `format` field has no effect on `FieldDef` (text channels). This PR fixes the issue.