### PR TITLE
feat: complete format during filling and support formatInLocalTime field.

### DIFF
--- a/packages/encodable/src/fillers/completeChannelDef.ts
+++ b/packages/encodable/src/fillers/completeChannelDef.ts
@@ -2,6 +2,7 @@ import { ChannelDef } from '../types/ChannelDef';
 import { ChannelType } from '../types/Channel';
 import { isFieldDef, isValueDef, isTypedFieldDef } from '../typeGuards/ChannelDef';
 import completeAxisConfig from './completeAxisConfig';
+import completeFormatConfig from './completeFormatConfig';
 import completeLegendConfig from './completeLegendConfig';
 import completeScaleConfig from './completeScaleConfig';
 import { Value } from '../types/VegaLite';
@@ -33,9 +34,11 @@ export default function completeChannelDef<Output extends Value>(
 
   // Scale needs the top-level properties to be filled.
   const scale = completeScaleConfig(channelType, copy);
-  const copy2 = { ...copy, scale };
+  // Format needs scale.
+  const format = completeFormatConfig({ ...channelDef, scaleType: scale ? scale.type : undefined });
+  const copy2 = { ...copy, ...format, scale };
 
-  // These two rely on scale
+  // These need scale and format
   const axis = completeAxisConfig(channelType, copy2);
   const legend = completeLegendConfig(channelType, copy2);
 

--- a/packages/encodable/src/fillers/completeFormatConfig.ts
+++ b/packages/encodable/src/fillers/completeFormatConfig.ts
@@ -1,0 +1,42 @@
+import { FormatMixins, Type, ScaleType, FormatType } from '../types/VegaLite';
+
+export type CompleteFormatConfig = {
+  formatType: 'time' | 'number' | undefined;
+  formatInLocalTime?: boolean;
+  format: string | undefined;
+};
+
+export default function completeFormatConfig(
+  config: FormatMixins & {
+    /** Field type */
+    type?: Type;
+    scaleType?: ScaleType;
+  },
+): CompleteFormatConfig {
+  const { formatType, formatInLocalTime, format, type, scaleType } = config;
+
+  let resolvedFormatType: FormatType | undefined;
+  if (typeof formatType !== 'undefined') {
+    resolvedFormatType = formatType;
+  } else if (type === 'quantitative') {
+    resolvedFormatType = 'number';
+  } else if (type === 'temporal' || scaleType === 'time' || scaleType === 'utc') {
+    resolvedFormatType = 'time';
+  } else if (typeof format !== 'undefined' && format.length > 0) {
+    resolvedFormatType = 'number';
+  }
+
+  if (resolvedFormatType === 'time') {
+    return {
+      formatType: 'time',
+      formatInLocalTime:
+        formatInLocalTime || (typeof formatInLocalTime === 'undefined' && scaleType === 'time'),
+      format,
+    };
+  }
+
+  return {
+    formatType: resolvedFormatType,
+    format,
+  };
+}

--- a/packages/encodable/src/types/ChannelDef.ts
+++ b/packages/encodable/src/types/ChannelDef.ts
@@ -17,7 +17,8 @@ export type Formatter = (d: unknown) => string;
 export interface FieldDef extends FormatMixins {
   field: string;
   title?: string;
-  bin?: boolean;
+  /** not used at the moment */
+  // bin?: boolean;
 }
 
 export interface TypedFieldDef extends FieldDef {

--- a/packages/encodable/src/types/CompleteChannelDef.ts
+++ b/packages/encodable/src/types/CompleteChannelDef.ts
@@ -3,6 +3,7 @@ import { CompleteAxisConfig } from '../fillers/completeAxisConfig';
 import { CompleteLegendConfig } from '../fillers/completeLegendConfig';
 import { CompleteScaleConfig } from '../fillers/completeScaleConfig';
 import { NonValueDef } from './ChannelDef';
+import { CompleteFormatConfig } from '../fillers/completeFormatConfig';
 
 export interface CompleteValueDef<Output extends Value = Value> extends ValueDef<Output> {
   axis: false;
@@ -11,11 +12,14 @@ export interface CompleteValueDef<Output extends Value = Value> extends ValueDef
   title: '';
 }
 
-export type HalfCompleteFieldDef<Output extends Value = Value> = NonValueDef<Output> & {
+export type HalfCompleteFieldDef<Output extends Value = Value> = Omit<
+  NonValueDef<Output>,
+  'formatType' | 'format' | 'formatInLocalTime' | 'scale' | 'title'
+> & {
   type: Type;
   scale: CompleteScaleConfig<Output>;
   title: string;
-};
+} & CompleteFormatConfig;
 
 export type HalfCompleteChannelDef<Output extends Value = Value> =
   | CompleteValueDef<Output>
@@ -23,7 +27,7 @@ export type HalfCompleteChannelDef<Output extends Value = Value> =
 
 export type CompleteFieldDef<Output extends Value = Value> = Omit<
   NonValueDef<Output>,
-  'title' | 'axis' | 'scale'
+  'title' | 'axis' | 'scale' | 'title'
 > & {
   type: Type;
   axis: CompleteAxisConfig;

--- a/packages/encodable/src/types/VegaLite/Mixins.ts
+++ b/packages/encodable/src/types/VegaLite/Mixins.ts
@@ -22,19 +22,22 @@ export interface FormatMixins {
    *
    * - If the format type is `"number"` (e.g., for quantitative fields), this is D3's [number format pattern](https://github.com/d3/d3-format#locale_format).
    * - If the format type is `"time"` (e.g., for temporal fields), this is D3's [time format pattern](https://github.com/d3/d3-time-format#locale_format).
-   *
-   * See the [format documentation](https://vega.github.io/vega-lite/docs/format.html) for more examples.
-   *
-   * __Default value:__  Derived from [numberFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for number format and from [timeFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for time format.
    */
   format?: string;
-
   /**
    * The format type for labels (`"number"` or `"time"`).
    *
    * __Default value:__
-   * - `"time"` for temporal fields and ordinal and nomimal fields with `timeUnit`.
-   * - `"number"` for quantitative fields as well as ordinal and nomimal fields without `timeUnit`.
+   * - `"time"` for temporal fields and ordinal and nominal fields with `timeUnit`.
+   * - `"number"` for quantitative fields as well as ordinal and nominal fields without `timeUnit`.
    */
   formatType?: FormatType;
+  // Not in vega-lite
+  /**
+   * Format in local time instead of UTC
+   * only applicable if formatType is time
+   *
+   * __Default value:__ false
+   */
+  formatInLocalTime?: boolean;
 }

--- a/packages/encodable/test/fillers/completeChannelDef.test.ts
+++ b/packages/encodable/test/fillers/completeChannelDef.test.ts
@@ -19,7 +19,8 @@ const DEFAULT_OUTPUT = {
     title: 'speed',
     titlePadding: 4,
   },
-  legend: false,
+  format: undefined,
+  formatType: 'number',
   scale: { type: 'linear', nice: true, clamp: true, zero: true },
 };
 


### PR DESCRIPTION
🏠  Internal

Instead of applying logic for deciding the appropriate formatter during parsing. Move the inference up to filling step.