### PR TITLE
refactor: simplify categorical color scale to be scale ordinal

### DIFF
--- a/packages/encodable/src/parsers/scale/createScaleFromScaleConfig.ts
+++ b/packages/encodable/src/parsers/scale/createScaleFromScaleConfig.ts
@@ -1,4 +1,4 @@
-import { CategoricalColorNamespace, CategoricalColorScale } from '@superset-ui/color';
+import { CategoricalColorNamespace } from '@superset-ui/color';
 import {
   ScaleLinear,
   ScaleLogarithmic,
@@ -72,12 +72,8 @@ function createScaleFromScaleConfig<Output extends Value>(
 ): ScaleThreshold<number | string | Date, Output>;
 
 function createScaleFromScaleConfig<Output extends Value>(
-  config: BinOrdinalScaleConfig<Output>,
+  config: OrdinalScaleConfig<Output> | BinOrdinalScaleConfig<Output>,
 ): ScaleOrdinal<CategoricalScaleInput, Output>;
-
-function createScaleFromScaleConfig<Output extends Value>(
-  config: OrdinalScaleConfig<Output>,
-): ScaleOrdinal<CategoricalScaleInput, Output> | CategoricalColorScale;
 
 function createScaleFromScaleConfig<Output extends Value>(
   config: PointScaleConfig<Output>,

--- a/packages/encodable/src/typeGuards/Scale.ts
+++ b/packages/encodable/src/typeGuards/Scale.ts
@@ -1,4 +1,3 @@
-import { CategoricalColorScale } from '@superset-ui/color';
 import { ScaleTime } from 'd3-scale';
 import {
   D3Scale,
@@ -58,34 +57,22 @@ export function isScaleConfigWithZero<Output extends Value = Value>(
   return isPropertySupportedByScaleType('zero', config.type);
 }
 
-export function isCategoricalColorScale<Output extends Value = Value>(
-  scale: D3Scale<Output> | CategoricalColorScale,
-): scale is CategoricalColorScale {
-  return scale instanceof CategoricalColorScale;
-}
-
-export function isD3Scale<Output extends Value = Value>(
-  scale: D3Scale<Output> | CategoricalColorScale,
-): scale is D3Scale<Output> {
-  return !isCategoricalColorScale(scale);
-}
-
 export function isContinuousScale<Output extends Value = Value>(
-  scale: D3Scale<Output> | CategoricalColorScale,
+  scale: D3Scale<Output>,
   scaleType: ScaleType,
 ): scale is ContinuousD3Scale<Output> {
   return scale && continuousScaleTypesSet.has(scaleType);
 }
 
 export function isDiscretizingScale<Output extends Value = Value>(
-  scale: D3Scale<Output> | CategoricalColorScale,
+  scale: D3Scale<Output>,
   scaleType: ScaleType,
 ): scale is DiscretizingD3Scale<Output> {
   return scale && discretizingScaleTypesSet.has(scaleType);
 }
 
 export function isTimeScale<Output extends Value = Value>(
-  scale: D3Scale<Output> | CategoricalColorScale,
+  scale: D3Scale<Output>,
   scaleType: ScaleType,
 ): scale is ScaleTime<Output, Output> {
   return scale && timeScaleTypesSet.has(scaleType);

--- a/packages/encodable/src/types/Scale.ts
+++ b/packages/encodable/src/types/Scale.ts
@@ -10,7 +10,6 @@ import {
   ScalePoint,
   ScaleBand,
 } from 'd3-scale';
-import { CategoricalColorScale } from '@superset-ui/color';
 import {
   Value,
   DateTime,
@@ -61,8 +60,6 @@ export interface CombinedScaleConfig<Output extends Value = Value>
   range?: Output[];
   /**
    * name of the color scheme.
-   * vega-lite also support SchemeParams object
-   * but encodable only accepts string at the moment
    */
   scheme?: string | SchemeParams;
   /**
@@ -245,4 +242,4 @@ export type D3Scale<Output extends Value = Value> =
   | ScalePoint<CategoricalScaleInput>
   | ScaleBand<CategoricalScaleInput>;
 
-export type AllScale<Output extends Value = Value> = D3Scale<Output> | CategoricalColorScale;
+export type AllScale<Output extends Value = Value> = D3Scale<Output>;

--- a/packages/encodable/test/typeGuards/Scale.test.ts
+++ b/packages/encodable/test/typeGuards/Scale.test.ts
@@ -1,4 +1,3 @@
-import { CategoricalColorScale } from '@superset-ui/color';
 import {
   scaleLinear,
   scaleOrdinal,
@@ -9,8 +8,6 @@ import {
   scaleQuantile,
 } from 'd3-scale';
 import {
-  isD3Scale,
-  isCategoricalColorScale,
   isTimeScale,
   isContinuousScaleConfig,
   isDiscretizingScaleConfig,
@@ -47,23 +44,6 @@ describe('type guards', () => {
     });
     it('returns false otherwise', () => {
       expect(isScaleConfigWithZero({ type: 'log' })).toBeFalsy();
-    });
-  });
-  describe('isD3Scale(scale)', () => {
-    it('returns true if it is one of D3 scales', () => {
-      expect(isD3Scale(scaleLinear())).toBeTruthy();
-      expect(isD3Scale(scaleOrdinal<HasToString, string>())).toBeTruthy();
-    });
-    it('returns false otherwise', () => {
-      expect(isD3Scale(new CategoricalColorScale(['red', 'yellow']))).toBeFalsy();
-    });
-  });
-  describe('isCategoricalColorScale(scale)', () => {
-    it('returns true if it is CategoricalColorScale', () => {
-      expect(isCategoricalColorScale(new CategoricalColorScale(['red', 'yellow']))).toBeTruthy();
-    });
-    it('returns false otherwise', () => {
-      expect(isCategoricalColorScale(scaleLinear())).toBeFalsy();
     });
   });
   describe('isContinuousScale(scale, type)', () => {


### PR DESCRIPTION
🏠  Internal

Decouple from `CategoricalColorScale` class and treat the scale as if it is a `ScaleOrdinal` for simplicity 