### PR TITLE
feat: can customize color scale resolver

### DIFF
--- a/docs/createScaleFromScaleConfig.md
+++ b/docs/createScaleFromScaleConfig.md
@@ -61,6 +61,5 @@ The following scale properties are supported. (See `Scale.ts`.)
 'reverse';
 'round';
 'scheme';
-'namespace';
 'zero';
 ```

--- a/packages/encodable/src/options/OptionsManager.ts
+++ b/packages/encodable/src/options/OptionsManager.ts
@@ -1,13 +1,19 @@
 import { getStore } from 'global-box';
 import defaultNumberFormatResolver from '../parsers/format/defaultNumberFormatResolver';
 import defaultTimeFormatResolver from '../parsers/format/defaultTimeFormatResolver';
-import { EncodableOptions, NumberFormatResolver, TimeFormatResolver } from '../types/Options';
+import defaultCategoricalColorScaleResolver from '../parsers/scale/defaultCategoricalColorScaleResolver';
+import {
+  EncodableOptions,
+  NumberFormatResolver,
+  TimeFormatResolver,
+  CategoricalColorScaleResolver,
+} from '../types/Options';
 
 let options: EncodableOptions;
 
 function getOptions() {
   if (!options) {
-    options = getStore().getOrCreate<EncodableOptions>('encodable', () => ({}));
+    options = getStore().getOrCreate<EncodableOptions>('encodable:options', () => ({}));
   }
   return options;
 }
@@ -26,6 +32,13 @@ const OptionsManager = {
   },
   setTimeFormatResolver(resolver: TimeFormatResolver | undefined) {
     getOptions().timeFormatResolver = resolver;
+    return this;
+  },
+  getCategoricalColorScaleResolver(): CategoricalColorScaleResolver {
+    return getOptions().categoricalColorScaleResolver ?? defaultCategoricalColorScaleResolver;
+  },
+  setCategoricalColorScaleResolver(resolver: CategoricalColorScaleResolver | undefined) {
+    getOptions().categoricalColorScaleResolver = resolver;
     return this;
   },
 };

--- a/packages/encodable/src/options/OptionsManager.ts
+++ b/packages/encodable/src/options/OptionsManager.ts
@@ -9,11 +9,13 @@ import {
   CategoricalColorScaleResolver,
 } from '../types/Options';
 
+const CACHE_KEY = 'encodable:options';
+
 let options: EncodableOptions;
 
 function getOptions() {
   if (!options) {
-    options = getStore().getOrCreate<EncodableOptions>('encodable:options', () => ({}));
+    options = getStore().getOrCreate<EncodableOptions>(CACHE_KEY, () => ({}));
   }
   return options;
 }

--- a/packages/encodable/src/parsers/scale/applyRange.ts
+++ b/packages/encodable/src/parsers/scale/applyRange.ts
@@ -11,7 +11,7 @@ export default function applyRange<Output extends Value>(
   if (typeof range === 'undefined') {
     if ('scheme' in config && typeof config.scheme !== 'undefined') {
       const { scheme } = config;
-      let name: string;
+      let name: string | undefined;
       let count: number | undefined;
 
       if (isContinuousScaleConfig(config) && domain) {

--- a/packages/encodable/src/parsers/scale/defaultCategoricalColorScaleResolver.ts
+++ b/packages/encodable/src/parsers/scale/defaultCategoricalColorScaleResolver.ts
@@ -1,0 +1,11 @@
+import { CategoricalColorNamespace } from '@superset-ui/color';
+import { CategoricalColorScaleResolver } from '../../types/Options';
+
+const defaultCategoricalColorScaleResolver: CategoricalColorScaleResolver = ({
+  name,
+  namespace,
+}) => {
+  return CategoricalColorNamespace.getScale(name, namespace);
+};
+
+export default defaultCategoricalColorScaleResolver;

--- a/packages/encodable/src/parsers/scale/isPropertySupportedByScaleType.ts
+++ b/packages/encodable/src/parsers/scale/isPropertySupportedByScaleType.ts
@@ -33,7 +33,6 @@ const supportedScaleTypes: Record<keyof CombinedScaleConfig, Set<ScaleType>> = {
   domain: allScaleTypesSet,
   exponent: new Set([ScaleType.POW]),
   interpolate: exceptPointOrBandSet,
-  namespace: new Set([ScaleType.ORDINAL]),
   nice: new Set(continuousScaleTypes.concat([ScaleType.QUANTIZE, ScaleType.THRESHOLD])),
   padding: continuousOrPointOrBandSet,
   paddingInner: new Set([ScaleType.BAND]),

--- a/packages/encodable/src/typeGuards/Scale.ts
+++ b/packages/encodable/src/typeGuards/Scale.ts
@@ -79,7 +79,5 @@ export function isTimeScale<Output extends Value = Value>(
 }
 
 export function isSchemeParams(scheme: string | SchemeParams): scheme is SchemeParams {
-  return (
-    Object.prototype.toString.call(scheme) !== '[object String]' && !!(scheme as SchemeParams).name
-  );
+  return Object.prototype.toString.call(scheme) !== '[object String]';
 }

--- a/packages/encodable/src/types/Options.ts
+++ b/packages/encodable/src/types/Options.ts
@@ -1,10 +1,22 @@
+import { ScaleOrdinal } from 'd3-scale';
+import { CategoricalScaleInput } from './Scale';
+
 export type NumberFormatter = (value: number | null | undefined) => string;
 export type NumberFormatResolver = (format?: string) => NumberFormatter;
 
 export type TimeFormatter = (value: Date | number | null | undefined) => string;
 export type TimeFormatResolver = (format?: string) => TimeFormatter;
 
+export type CategoricalColorScaleResolver = (params: {
+  name?: string;
+  namespace?: string;
+}) => ScaleOrdinal<CategoricalScaleInput, string>;
+
+/**
+ * All fields are optional.
+ */
 export type EncodableOptions = Partial<{
   numberFormatResolver: NumberFormatResolver;
   timeFormatResolver: TimeFormatResolver;
+  categoricalColorScaleResolver: CategoricalColorScaleResolver;
 }>;

--- a/packages/encodable/src/types/Scale.ts
+++ b/packages/encodable/src/types/Scale.ts
@@ -63,11 +63,6 @@ export interface CombinedScaleConfig<Output extends Value = Value>
    */
   scheme?: string | SchemeParams;
   /**
-   * color namespace.
-   * vega-lite does not have this field
-   */
-  namespace?: string;
-  /**
    * Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of _[0.201479…, 0.996679…]_, a nice domain might be _[0.2, 1.0]_.
    *
    * For quantitative scales such as linear, `nice` can be either a boolean flag or a number. If `nice` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain.
@@ -162,7 +157,7 @@ export interface BinOrdinalScaleConfig<Output extends Value = Value>
 }
 
 export interface OrdinalScaleConfig<Output extends Value = Value>
-  extends PickFromCombinedScaleConfig<Output, 'interpolate' | 'scheme' | 'namespace'> {
+  extends PickFromCombinedScaleConfig<Output, 'interpolate' | 'scheme'> {
   type: 'ordinal';
 }
 

--- a/packages/encodable/src/types/VegaLite/SchemeParams.ts
+++ b/packages/encodable/src/types/VegaLite/SchemeParams.ts
@@ -1,10 +1,22 @@
 export interface SchemeParams {
   /**
    * A color scheme name for ordinal scales (e.g., `"category10"` or `"blues"`).
-   *
-   * For the full list of supported schemes, please refer to the [Vega Scheme](https://vega.github.io/vega/docs/schemes/#reference) reference.
    */
-  name: string;
+  name?: string;
+
+  /**
+   * Color namespace.
+   * Using an ordinal scale with the same scheme name,
+   * will point to the same scale instance.
+   * Using namespace can control the scale sharing.
+   * By default, all scales are considered to be in the default namespace.
+   * If this field is specified, e.g. 'a'.
+   * Only ordinal scale with same scheme name and namespace 'a'
+   * will be pointed to this same scale instance.
+   *
+   * __Note:__ Vega-Lite does not have this field.
+   */
+  namespace?: string;
 
   /**
    * The extent of the color range to use. For example `[0.2, 1]` will rescale the color scheme such that color values in the range _[0, 0.2)_ are excluded from the scheme.

--- a/packages/encodable/test/options/OptionsManager.test.ts
+++ b/packages/encodable/test/options/OptionsManager.test.ts
@@ -1,12 +1,15 @@
-import { OptionsManager } from '../../src';
+import { scaleOrdinal } from 'd3-scale';
+import { OptionsManager, CategoricalScaleInput } from '../../src';
 
 const dummyFormatter = () => 'haha';
+const dummyScaleResolver = () => scaleOrdinal<CategoricalScaleInput, string>(['haha']);
 
 describe('OptionsManager', () => {
   afterEach(() => {
     // reset format resolvers
-    OptionsManager.setNumberFormatResolver(undefined);
-    OptionsManager.setTimeFormatResolver(undefined);
+    OptionsManager.setNumberFormatResolver(undefined)
+      .setTimeFormatResolver(undefined)
+      .setCategoricalColorScaleResolver(undefined);
   });
 
   describe('.getNumberFormatResolver(resolver)', () => {
@@ -43,6 +46,26 @@ describe('OptionsManager', () => {
     });
     it('returns OptionsManager', () => {
       expect(OptionsManager.setTimeFormatResolver(() => dummyFormatter)).toBe(OptionsManager);
+    });
+  });
+  describe('.getCategoricalColorScaleResolver(resolver)', () => {
+    it('returns a resolver', () => {
+      const resolver = OptionsManager.getCategoricalColorScaleResolver();
+      expect(resolver).toBeDefined();
+      expect(typeof resolver({})('abc')).toBe('string');
+    });
+  });
+  describe('.setCategoricalColorScaleResolver(resolver)', () => {
+    it('sets a resolver', () => {
+      OptionsManager.setCategoricalColorScaleResolver(dummyScaleResolver);
+      const resolver = OptionsManager.getCategoricalColorScaleResolver();
+      expect(resolver).toBeDefined();
+      expect(resolver({})('abc')).toEqual('haha');
+    });
+    it('returns OptionsManager', () => {
+      expect(OptionsManager.setCategoricalColorScaleResolver(dummyScaleResolver)).toBe(
+        OptionsManager,
+      );
     });
   });
 });

--- a/packages/encodable/test/parsers/scale/createScaleFromScaleConfig.test.ts
+++ b/packages/encodable/test/parsers/scale/createScaleFromScaleConfig.test.ts
@@ -649,15 +649,15 @@ describe('createScaleFromScaleConfig(config)', () => {
     it('with namespace', () => {
       const scale1 = createScaleFromScaleConfig({
         type: 'ordinal',
-        namespace: 'abc',
+        scheme: { namespace: 'abc' },
       });
       const scale2 = createScaleFromScaleConfig({
         type: 'ordinal',
-        namespace: 'def',
+        scheme: { namespace: 'def' },
       });
       const scale3 = createScaleFromScaleConfig({
         type: 'ordinal',
-        namespace: 'def',
+        scheme: { namespace: 'def' },
       });
 
       expect(scale1('fish')).toEqual('red');


### PR DESCRIPTION
💔  Breaking Changes

`channelDef.namespace` is now `channelDef.scheme.namespace` as part of `SchemeParams`.

🏆 Enhancements

* Add `.setCategoricalColorScaleResolver()` and `.getCategoricalColorScaleResolver()`
