### PR TITLE
feat: simplify global store creation and add docs

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -18,8 +18,7 @@
       "graphType": "all"
     },
     "version": {
-      "message": "chore: publish",
-      "exact": true
+      "message": "chore: publish"
     }
   }
 }

--- a/packages/encodable-format/package.json
+++ b/packages/encodable-format/package.json
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@encodable/registry": "0.1.2",
+    "@encodable/registry": "^0.1.2",
     "@types/d3-format": "^1.3.1",
     "@types/d3-time": "^1.0.10",
     "@types/d3-time-format": "^2.1.1",

--- a/packages/encodable-format/src/number/index.ts
+++ b/packages/encodable-format/src/number/index.ts
@@ -5,7 +5,6 @@ import { NumberFormatInput } from '../types';
 export const getNumberFormatterRegistry = makeSingleton(
   () =>
     new NumberFormatterRegistry({
-      isGlobal: true,
       globalId: '@encodable/format:NumberFormatterRegistry',
     }),
 );

--- a/packages/encodable-format/src/time/index.ts
+++ b/packages/encodable-format/src/time/index.ts
@@ -5,7 +5,6 @@ import { TimeFormatInput } from '../types';
 export const getTimeFormatterRegistry = makeSingleton(
   () =>
     new TimeFormatterRegistry({
-      isGlobal: true,
       globalId: '@encodable/format:TimeFormatterRegistry',
     }),
 );

--- a/packages/encodable-format/src/timeRange/index.ts
+++ b/packages/encodable-format/src/timeRange/index.ts
@@ -5,7 +5,6 @@ import { TimeFormatInput } from '../types';
 export const getTimeRangeFormatterRegistry = makeSingleton(
   () =>
     new TimeRangeFormatterRegistry({
-      isGlobal: true,
       globalId: '@encodable/format:TimeRangeFormatterRegistry',
     }),
 );

--- a/packages/encodable-registry/src/models/SyncRegistry.ts
+++ b/packages/encodable-registry/src/models/SyncRegistry.ts
@@ -1,3 +1,6 @@
 import Registry from './Registry';
 
+/**
+ * Synchronous registry
+ */
 export default class SyncRegistry<V> extends Registry<V, V> {}

--- a/packages/encodable-registry/src/models/createRegistryStore.ts
+++ b/packages/encodable-registry/src/models/createRegistryStore.ts
@@ -1,13 +1,19 @@
-import { RegistryStoreConfig, RegistryStore } from '../types';
+import { RegistryConfig, RegistryStore } from '../types';
 import OverwritePolicy from './OverwritePolicy';
 
+/**
+ * Create a registry store from the given config
+ * @param config
+ */
 export default function createRegistryStore<V, W extends V | Promise<V>>({
-  name = '',
+  globalId,
+  name,
   defaultKey,
   setFirstItemAsDefault = false,
   overwritePolicy = OverwritePolicy.ALLOW,
-}: RegistryStoreConfig): RegistryStore<V, W> {
+}: RegistryConfig): RegistryStore<V, W> {
   return {
+    globalId,
     name,
     defaultKey,
     initialDefaultKey: defaultKey,

--- a/packages/encodable-registry/src/types/index.ts
+++ b/packages/encodable-registry/src/types/index.ts
@@ -1,34 +1,59 @@
 import OverwritePolicy from '../models/OverwritePolicy';
 
-interface ItemWithValue<T> {
-  value: T;
+interface ItemWithValue<V> {
+  /** stored value */
+  value: V;
 }
 
-interface ItemWithLoader<T> {
-  loader: () => T;
+interface ItemWithLoader<L> {
+  /** function that returns value */
+  loader: () => L;
 }
 
-export interface RegistryStore<V, W extends V | Promise<V>> {
-  name: string;
+export interface RegistryStore<V, L extends V | Promise<V>> {
+  /**
+   * If this is a global registry, it will be defined.
+   */
+  globalId?: string;
+  /** name of this registry */
+  name?: string;
+  /**
+   * fallback key to use if `.get()` was called without a key
+   * This was the initial value when the registry was created.
+   */
   initialDefaultKey?: string;
+  /**
+   * fallback key to use if `.get()` was called without a key
+   * This is the current default key.
+   */
   defaultKey?: string;
+  /** set the first item registered as the default */
   setFirstItemAsDefault: boolean;
+  /** define if registering with an existing key is allowed, prohibited or warned */
   overwritePolicy: OverwritePolicy;
-  items: {
-    [key: string]: ItemWithValue<V> | ItemWithLoader<W>;
-  };
 
+  /** map to lookup items by key */
+  items: {
+    [key: string]: ItemWithValue<V> | ItemWithLoader<L>;
+  };
+  /** map to lookup promises by key */
   promises: {
     [key: string]: Promise<V>;
   };
 }
 
-export interface RegistryStoreConfig {
+export interface RegistryConfig {
+  /**
+   * Set this value to define a global registry.
+   * This will make it a true singleton and accessible via this `globalId` from any package.
+   */
+  globalId?: string;
+  /** name of this registry */
   name?: string;
+  /** fallback key to use if `.get()` was called without a key */
   defaultKey?: string;
+  /** set the first item registered as the default */
   setFirstItemAsDefault?: boolean;
+  /** define if registering with an existing key is allowed, prohibited or warned */
   overwritePolicy?: OverwritePolicy;
 }
-
-export type RegistryConfig = RegistryStoreConfig &
-  ({ isGlobal?: false } | { isGlobal: true; globalId: string });

--- a/packages/encodable-registry/src/utils/makeSingleton.ts
+++ b/packages/encodable-registry/src/utils/makeSingleton.ts
@@ -1,3 +1,7 @@
+/**
+ * Helper function for creating a singleton
+ * @param create factory function
+ */
 export default function makeSingleton<T>(create: () => T) {
   let singleton: T | undefined;
 

--- a/packages/encodable-registry/test/models/Registry.test.ts
+++ b/packages/encodable-registry/test/models/Registry.test.ts
@@ -473,9 +473,9 @@ describe('Registry', () => {
 
   describe('config.global', () => {
     it('refer to the global object with same id', () => {
-      const r1 = new Registry({ isGlobal: true, globalId: 'test1' });
+      const r1 = new Registry({ globalId: 'test1' });
       r1.registerValue('a', 100);
-      const r2 = new Registry({ isGlobal: true, globalId: 'test1' });
+      const r2 = new Registry({ globalId: 'test1' });
       expect(r2.get('a')).toEqual(100);
     });
   });


### PR DESCRIPTION
💔 Breaking Changes

* When creating `Registry`, `isGlobal` flag is no longer used. Only determine from `globalId` field if defined. 

📜 Documentation

Add documentation 
