### PR TITLE
feat(color): add scheme wrappers

### DIFF
--- a/packages/encodable-color/package.json
+++ b/packages/encodable-color/package.json
@@ -31,7 +31,9 @@
     "@encodable/registry": "^0.4.0",
     "@types/d3-interpolate": "^1.3.1",
     "@types/d3-scale": "^2.2.0",
+    "@types/d3-scale-chromatic": "^1.2.0",
     "d3-interpolate": "^1.4.0",
-    "d3-scale": "^3.2.1"
+    "d3-scale": "^3.2.1",
+    "d3-scale-chromatic": "^1.5.0"
   }
 }

--- a/packages/encodable-color/src/scale/ColorNamespace.ts
+++ b/packages/encodable-color/src/scale/ColorNamespace.ts
@@ -5,9 +5,9 @@ import { ColorNamespaceStore } from './types';
 import ScaleCategoricalColor from './ScaleCategoricalColor';
 
 export default class ColorNamespace {
-  store: ColorNamespaceStore;
+  readonly store: ColorNamespaceStore;
 
-  scales: SyncRegistry<ScaleCategoricalColor>;
+  readonly scales: SyncRegistry<ScaleCategoricalColor>;
 
   constructor(nameOrStore: string | ColorNamespaceStore) {
     this.store =
@@ -87,16 +87,17 @@ export default class ColorNamespace {
       this.scales.registerValue(schemeName, scale);
       return scale;
     }
-    if (!this.scales.has(schemeName)) {
-      // create scale
-      const scale = new ScaleCategoricalColor(
-        this.store.scales[schemeName]!,
-        this.store.manualColors,
-      );
-      this.scales.registerValue(schemeName, scale);
-      return scale;
+
+    if (this.scales.has(schemeName)) {
+      return this.scales.get(schemeName)!;
     }
 
-    return this.scales.get(schemeName)!;
+    // create scale
+    const scale = new ScaleCategoricalColor(
+      this.store.scales[schemeName]!,
+      this.store.manualColors,
+    );
+    this.scales.registerValue(schemeName, scale);
+    return scale;
   }
 }

--- a/packages/encodable-color/src/scale/ColorNamespaceRegistry.ts
+++ b/packages/encodable-color/src/scale/ColorNamespaceRegistry.ts
@@ -5,9 +5,9 @@ import ColorNamespace from './ColorNamespace';
 export const DEFAULT_NAMESPACE = 'DEFAULT_NAMESPACE';
 
 export default class ColorNamespaceRegistry {
-  private namespaceStores: SyncRegistry<ColorNamespaceStore>;
+  private readonly namespaceStores: SyncRegistry<ColorNamespaceStore>;
 
-  private namespaceInstances: SyncRegistry<ColorNamespace>;
+  private readonly namespaceInstances: SyncRegistry<ColorNamespace>;
 
   constructor({ name = 'ColorNamespaceRegistry', globalId, ...rest }: RegistryConfig = {}) {
     // only make the store global is using globalId
@@ -43,13 +43,13 @@ export default class ColorNamespaceRegistry {
       return ns;
     }
 
-    if (!this.namespaceInstances.has(namespace)) {
-      const ns = new ColorNamespace(this.namespaceStores.get(namespace)!);
-      this.namespaceInstances.registerValue(namespace, ns);
-      return ns;
+    if (this.namespaceInstances.has(namespace)) {
+      return this.namespaceInstances.get(namespace)!;
     }
 
-    return this.namespaceInstances.get(namespace)!;
+    const ns = new ColorNamespace(this.namespaceStores.get(namespace)!);
+    this.namespaceInstances.registerValue(namespace, ns);
+    return ns;
   }
 
   keys() {

--- a/packages/encodable-color/src/scale/ScaleCategoricalColor.ts
+++ b/packages/encodable-color/src/scale/ScaleCategoricalColor.ts
@@ -74,7 +74,7 @@ class ScaleCategoricalColor extends ExtensibleFunction {
   getColorMap() {
     const colorMap: { [key: string]: string } = {};
     this.store.scale.domain().forEach(value => {
-      colorMap[value.toString()] = this.store.scale(value);
+      colorMap[String(value)] = this.store.scale(value);
     });
 
     return {
@@ -111,7 +111,7 @@ class ScaleCategoricalColor extends ExtensibleFunction {
 
   domain(newDomain?: { toString(): string }[]): unknown {
     if (typeof newDomain === 'undefined') {
-      return this.store.scale.domain();
+      return this.store.scale.domain() as string[];
     }
 
     this.store.scale.domain(newDomain);

--- a/packages/encodable-color/src/scheme/ChildRegistry.ts
+++ b/packages/encodable-color/src/scheme/ChildRegistry.ts
@@ -28,7 +28,10 @@ export default class ChildRegistry<
   }
 
   get(key?: string): Wrapper | undefined {
-    return this.has(key) ? (this.parent.get(key)! as Wrapper) : undefined;
+    const targetKey = key ?? this.getDefaultKey();
+    return typeof targetKey !== 'undefined' && this.has(targetKey)
+      ? (this.parent.get(key)! as Wrapper)
+      : undefined;
   }
 
   _registerValue(key: string, value: Scheme) {

--- a/packages/encodable-color/src/scheme/ChildRegistry.ts
+++ b/packages/encodable-color/src/scheme/ChildRegistry.ts
@@ -28,7 +28,7 @@ export default class ChildRegistry<
   }
 
   get(key?: string): Wrapper | undefined {
-    return this.has(key) ? (this.parent.get(key) as Wrapper) : undefined;
+    return this.has(key) ? (this.parent.get(key)! as Wrapper) : undefined;
   }
 
   _registerValue(key: string, value: Scheme) {

--- a/packages/encodable-color/src/scheme/ChildRegistry.ts
+++ b/packages/encodable-color/src/scheme/ChildRegistry.ts
@@ -1,14 +1,16 @@
 /* eslint-disable no-underscore-dangle */
 import { SyncRegistry, RegistryConfig } from '@encodable/registry';
 import { ColorScheme } from '../types';
-import createWrapper from './createWrapper';
 
 type ChildRegistryConfig = Pick<RegistryConfig, 'defaultKey'> & {
   name: string;
 };
 
-export default class ChildRegistry<V extends ColorScheme> extends SyncRegistry<V> {
-  parent: SyncRegistry<ColorScheme>;
+export default class ChildRegistry<
+  Scheme extends ColorScheme,
+  Wrapper extends Scheme
+> extends SyncRegistry<Scheme> {
+  private readonly parent: SyncRegistry<ColorScheme>;
 
   constructor(parent: SyncRegistry<ColorScheme>, { name, defaultKey }: ChildRegistryConfig) {
     super({
@@ -25,25 +27,24 @@ export default class ChildRegistry<V extends ColorScheme> extends SyncRegistry<V
     this.parent = parent;
   }
 
-  get(key?: string) {
-    const value = super.get(key);
-    return typeof value === 'undefined' ? value : createWrapper(value);
+  get(key?: string): Wrapper | undefined {
+    return this.has(key) ? (this.parent.get(key) as Wrapper) : undefined;
   }
 
-  _registerValue(key: string, value: V) {
+  _registerValue(key: string, value: Scheme) {
     return super.registerValue(key, value);
   }
 
-  registerValue(key: string, value: V) {
+  registerValue(key: string, value: Scheme) {
     this.parent.registerValue(key, value);
     return this;
   }
 
-  _registerLoader(key: string, loader: () => V) {
+  _registerLoader(key: string, loader: () => Scheme) {
     return super.registerLoader(key, loader);
   }
 
-  registerLoader(key: string, loader: () => V) {
+  registerLoader(key: string, loader: () => Scheme) {
     this.parent.registerLoader(key, loader);
     return this;
   }

--- a/packages/encodable-color/src/scheme/ColorSchemeRegistry.ts
+++ b/packages/encodable-color/src/scheme/ColorSchemeRegistry.ts
@@ -2,7 +2,7 @@
 import { SyncRegistry, OverwritePolicy, RegistryConfig } from '@encodable/registry';
 import { ColorScheme, CategoricalScheme, SequentialScheme, DivergingScheme } from '../types';
 import ChildRegistry from './ChildRegistry';
-import createWrapper, { ColorSchemeWrapper } from './wrappers/createWrapper';
+import wrapColorScheme, { ColorSchemeWrapper } from './wrappers/wrapColorScheme';
 import CategoricalSchemeWrapper from './wrappers/CategoricalSchemeWrapper';
 import SequentialSchemeWrapper from './wrappers/SequentialSchemeWrapper';
 import DivergingSchemeWrapper from './wrappers/DivergingSchemeWrapper';
@@ -53,7 +53,7 @@ export default class ColorSchemeRegistry extends SyncRegistry<ColorScheme> {
       return this.wrappers.get(key);
     }
 
-    const wrapper = createWrapper(value);
+    const wrapper = wrapColorScheme(value);
     this.wrappers.registerValue(targetKey, wrapper);
     return wrapper;
   }

--- a/packages/encodable-color/src/scheme/ColorSchemeRegistry.ts
+++ b/packages/encodable-color/src/scheme/ColorSchemeRegistry.ts
@@ -38,19 +38,25 @@ export default class ColorSchemeRegistry extends SyncRegistry<ColorScheme> {
     this.wrappers = new SyncRegistry<ColorSchemeWrapper>();
   }
 
-  get(key?: string): ColorSchemeWrapper {
-    const value = super.get(key);
+  get(key?: string): ColorSchemeWrapper | undefined {
+    const targetKey = key ?? this.getDefaultKey();
+
+    if (typeof targetKey === 'undefined') {
+      return undefined;
+    }
+
+    const value = super.get(targetKey);
 
     if (typeof value === 'undefined') {
       return value;
     }
 
-    if (this.wrappers.has(key)) {
+    if (this.wrappers.has(targetKey)) {
       return this.wrappers.get(key);
     }
 
     const wrapper = createWrapper(value);
-    this.wrappers.registerValue(key, wrapper);
+    this.wrappers.registerValue(targetKey, wrapper);
     return wrapper;
   }
 

--- a/packages/encodable-color/src/scheme/ColorSchemeRegistry.ts
+++ b/packages/encodable-color/src/scheme/ColorSchemeRegistry.ts
@@ -2,12 +2,10 @@
 import { SyncRegistry, OverwritePolicy, RegistryConfig } from '@encodable/registry';
 import { ColorScheme, CategoricalScheme, SequentialScheme, DivergingScheme } from '../types';
 import ChildRegistry from './ChildRegistry';
-import createWrapper from './wrappers/createWrapper';
+import createWrapper, { ColorSchemeWrapper } from './wrappers/createWrapper';
 import CategoricalSchemeWrapper from './wrappers/CategoricalSchemeWrapper';
 import SequentialSchemeWrapper from './wrappers/SequentialSchemeWrapper';
 import DivergingSchemeWrapper from './wrappers/DivergingSchemeWrapper';
-
-type ColorSchemeWrapper = ReturnType<typeof createWrapper>;
 
 export default class ColorSchemeRegistry extends SyncRegistry<ColorScheme> {
   readonly categorical: ChildRegistry<CategoricalScheme, CategoricalSchemeWrapper>;

--- a/packages/encodable-color/src/scheme/createWrapper.ts
+++ b/packages/encodable-color/src/scheme/createWrapper.ts
@@ -1,5 +1,0 @@
-import { ColorScheme } from '../types';
-
-export default function createWrapper<T extends ColorScheme>(scheme: T): T {
-  return scheme;
-}

--- a/packages/encodable-color/src/scheme/wrappers/CategoricalSchemeWrapper.ts
+++ b/packages/encodable-color/src/scheme/wrappers/CategoricalSchemeWrapper.ts
@@ -1,0 +1,30 @@
+import { scaleOrdinal } from 'd3-scale';
+import { CategoricalScheme } from '../../types';
+import SchemeWrapper from './SchemeWrapper';
+
+export default class CategoricalSchemeWrapper extends SchemeWrapper<CategoricalScheme> {
+  get colors() {
+    return this.scheme.colors;
+  }
+
+  getColors(numColors?: number) {
+    const { length } = this.scheme.colors;
+    if (typeof numColors === 'undefined' || numColors === length) {
+      return this.scheme.colors;
+    }
+    if (numColors < length) {
+      return this.scheme.colors.slice(0, numColors);
+    }
+
+    const times = Math.ceil(numColors / length);
+    let output = this.scheme.colors.slice();
+    for (let i = 0; i < times; i += 1) {
+      output = output.concat(this.scheme.colors);
+    }
+    return output.slice(0, numColors);
+  }
+
+  createScaleOrdinal() {
+    return scaleOrdinal(this.scheme.colors);
+  }
+}

--- a/packages/encodable-color/src/scheme/wrappers/ContinuousSchemeWrapper.ts
+++ b/packages/encodable-color/src/scheme/wrappers/ContinuousSchemeWrapper.ts
@@ -7,17 +7,17 @@ export default class ContinuousSchemeWrapper<
   T extends SequentialScheme | DivergingScheme
 > extends SchemeWrapper<T> {
   get colors() {
-    if ('colors' in this.scheme) {
+    if ('colors' in this.scheme && typeof this.scheme.colors !== 'undefined') {
       return this.scheme.colors;
     }
     return this.getColors();
   }
 
   get interpolator() {
-    if ('interpolator' in this.scheme) {
+    if ('interpolator' in this.scheme && typeof this.scheme.interpolator !== 'undefined') {
       return this.scheme.interpolator;
     }
-    return piecewise(interpolateRgb, this.scheme.colors) as ColorInterpolator;
+    return piecewise(interpolateRgb, this.scheme.colors!) as ColorInterpolator;
   }
 
   /**
@@ -31,6 +31,7 @@ export default class ContinuousSchemeWrapper<
   getColors(numColors: number = 2, extent: number[] = [0, 1]): string[] {
     if (
       'colors' in this.scheme &&
+      typeof this.scheme.colors !== 'undefined' &&
       numColors === this.scheme.colors.length &&
       extent[0] === 0 &&
       extent[1] === 1

--- a/packages/encodable-color/src/scheme/wrappers/ContinuousSchemeWrapper.ts
+++ b/packages/encodable-color/src/scheme/wrappers/ContinuousSchemeWrapper.ts
@@ -1,0 +1,52 @@
+import { interpolateRgb, piecewise, quantize } from 'd3-interpolate';
+import { scaleSequential, scaleLinear, ScaleLinear } from 'd3-scale';
+import { ColorInterpolator, SequentialScheme, DivergingScheme } from '../../types';
+import SchemeWrapper from './SchemeWrapper';
+
+export default class ContinuousSchemeWrapper<
+  T extends SequentialScheme | DivergingScheme
+> extends SchemeWrapper<T> {
+  get colors() {
+    if ('colors' in this.scheme) {
+      return this.scheme.colors;
+    }
+    return this.getColors();
+  }
+
+  get interpolator() {
+    if ('interpolator' in this.scheme) {
+      return this.scheme.interpolator;
+    }
+    return piecewise(interpolateRgb, this.scheme.colors) as ColorInterpolator;
+  }
+
+  /**
+   * Get colors from this scheme
+   * @param numColors number of colors to return.
+   * Will interpolate the current scheme to match the number of colors requested
+   * @param extent The extent of the color range to use.
+   * For example [0.2, 1] will rescale the color scheme
+   * such that color values in the range [0, 0.2) are excluded from the scheme.
+   */
+  getColors(numColors: number = 2, extent: number[] = [0, 1]): string[] {
+    if (
+      'colors' in this.scheme &&
+      numColors === this.scheme.colors.length &&
+      extent[0] === 0 &&
+      extent[1] === 1
+    ) {
+      return this.scheme.colors;
+    }
+
+    const { interpolator } = this;
+    const adjustExtent = scaleLinear().range(extent).clamp(true);
+    return quantize<string>(t => interpolator(adjustExtent(t)), numColors);
+  }
+
+  createScaleLinear() {
+    // The manual casting is necessary until @types/d3-scale is corrected
+    // In recent version of d3-scale the output from scaleSequential is compatible with linear scale
+    // (It has .range(),  ...)
+    return (scaleSequential(this.interpolator) as unknown) as ScaleLinear<string, string>;
+  }
+}

--- a/packages/encodable-color/src/scheme/wrappers/DivergingSchemeWrapper.ts
+++ b/packages/encodable-color/src/scheme/wrappers/DivergingSchemeWrapper.ts
@@ -1,0 +1,13 @@
+import { scaleDiverging, ScaleLinear } from 'd3-scale';
+import ContinuousSchemeWrapper from './ContinuousSchemeWrapper';
+import { DivergingScheme } from '../../types';
+
+export default class DivergingSchemeWrapper extends ContinuousSchemeWrapper<DivergingScheme> {
+  getColors(numColors: number = 3, extent: number[] = [0, 1]): string[] {
+    return super.getColors(numColors, extent);
+  }
+
+  createScaleLinear() {
+    return (scaleDiverging(this.interpolator) as unknown) as ScaleLinear<string, string>;
+  }
+}

--- a/packages/encodable-color/src/scheme/wrappers/SchemeWrapper.ts
+++ b/packages/encodable-color/src/scheme/wrappers/SchemeWrapper.ts
@@ -1,0 +1,29 @@
+import { ColorScheme } from '../../types';
+
+export default abstract class SchemeWrapper<T extends ColorScheme> {
+  protected readonly scheme: T;
+
+  constructor(scheme: T) {
+    this.scheme = scheme;
+  }
+
+  /** scheme type */
+  get type(): T['type'] {
+    return this.scheme.type;
+  }
+
+  /** id of this scheme */
+  get id() {
+    return this.scheme.id;
+  }
+
+  /** human-friendly name to refer to */
+  get label() {
+    return this.scheme.label;
+  }
+
+  /** more description (if any) */
+  get description() {
+    return this.scheme.description;
+  }
+}

--- a/packages/encodable-color/src/scheme/wrappers/SequentialSchemeWrapper.ts
+++ b/packages/encodable-color/src/scheme/wrappers/SequentialSchemeWrapper.ts
@@ -1,0 +1,4 @@
+import { SequentialScheme } from '../../types';
+import ContinuousSchemeWrapper from './ContinuousSchemeWrapper';
+
+export default class SequentialSchemeWrapper extends ContinuousSchemeWrapper<SequentialScheme> {}

--- a/packages/encodable-color/src/scheme/wrappers/createWrapper.ts
+++ b/packages/encodable-color/src/scheme/wrappers/createWrapper.ts
@@ -3,15 +3,33 @@ import CategoricalSchemeWrapper from './CategoricalSchemeWrapper';
 import SequentialSchemeWrapper from './SequentialSchemeWrapper';
 import DivergingSchemeWrapper from './DivergingSchemeWrapper';
 
-export default function createWrapper<T extends ColorScheme>(scheme: T) {
+export type ColorSchemeWrapper =
+  | CategoricalSchemeWrapper
+  | SequentialSchemeWrapper
+  | DivergingSchemeWrapper;
+
+function createWrapper(scheme: CategoricalScheme): CategoricalSchemeWrapper;
+function createWrapper(scheme: SequentialScheme): SequentialSchemeWrapper;
+function createWrapper(scheme: DivergingScheme): DivergingSchemeWrapper;
+function createWrapper(scheme: ColorScheme): ColorSchemeWrapper;
+
+function createWrapper<T extends ColorScheme>(scheme: T) {
   switch (scheme.type) {
     case 'categorical':
-      return new CategoricalSchemeWrapper(scheme as CategoricalScheme);
+      return scheme instanceof CategoricalSchemeWrapper
+        ? scheme
+        : new CategoricalSchemeWrapper(scheme as CategoricalScheme);
     case 'sequential':
-      return new SequentialSchemeWrapper(scheme as SequentialScheme);
+      return scheme instanceof SequentialSchemeWrapper
+        ? scheme
+        : new SequentialSchemeWrapper(scheme as SequentialScheme);
     case 'diverging':
-      return new DivergingSchemeWrapper(scheme as DivergingScheme);
+      return scheme instanceof DivergingSchemeWrapper
+        ? scheme
+        : new DivergingSchemeWrapper(scheme as DivergingScheme);
     default:
       throw new Error(`Unknown scheme type: ${scheme.type}`);
   }
 }
+
+export default createWrapper;

--- a/packages/encodable-color/src/scheme/wrappers/createWrapper.ts
+++ b/packages/encodable-color/src/scheme/wrappers/createWrapper.ts
@@ -1,0 +1,17 @@
+import { ColorScheme, CategoricalScheme, SequentialScheme, DivergingScheme } from '../../types';
+import CategoricalSchemeWrapper from './CategoricalSchemeWrapper';
+import SequentialSchemeWrapper from './SequentialSchemeWrapper';
+import DivergingSchemeWrapper from './DivergingSchemeWrapper';
+
+export default function createWrapper<T extends ColorScheme>(scheme: T) {
+  switch (scheme.type) {
+    case 'categorical':
+      return new CategoricalSchemeWrapper(scheme as CategoricalScheme);
+    case 'sequential':
+      return new SequentialSchemeWrapper(scheme as SequentialScheme);
+    case 'diverging':
+      return new DivergingSchemeWrapper(scheme as DivergingScheme);
+    default:
+      throw new Error(`Unknown scheme type: ${scheme.type}`);
+  }
+}

--- a/packages/encodable-color/src/scheme/wrappers/wrapColorScheme.ts
+++ b/packages/encodable-color/src/scheme/wrappers/wrapColorScheme.ts
@@ -8,12 +8,12 @@ export type ColorSchemeWrapper =
   | SequentialSchemeWrapper
   | DivergingSchemeWrapper;
 
-function createWrapper(scheme: CategoricalScheme): CategoricalSchemeWrapper;
-function createWrapper(scheme: SequentialScheme): SequentialSchemeWrapper;
-function createWrapper(scheme: DivergingScheme): DivergingSchemeWrapper;
-function createWrapper(scheme: ColorScheme): ColorSchemeWrapper;
+function wrapColorScheme(scheme: CategoricalScheme): CategoricalSchemeWrapper;
+function wrapColorScheme(scheme: SequentialScheme): SequentialSchemeWrapper;
+function wrapColorScheme(scheme: DivergingScheme): DivergingSchemeWrapper;
+function wrapColorScheme(scheme: ColorScheme): ColorSchemeWrapper;
 
-function createWrapper<T extends ColorScheme>(scheme: T) {
+function wrapColorScheme<T extends ColorScheme>(scheme: T) {
   switch (scheme.type) {
     case 'categorical':
       return scheme instanceof CategoricalSchemeWrapper
@@ -32,4 +32,4 @@ function createWrapper<T extends ColorScheme>(scheme: T) {
   }
 }
 
-export default createWrapper;
+export default wrapColorScheme;

--- a/packages/encodable-color/src/types.ts
+++ b/packages/encodable-color/src/types.ts
@@ -3,7 +3,7 @@ export type ColorSchemeType = 'categorical' | 'sequential' | 'diverging';
 type BaseColorScheme<T extends ColorSchemeType> = {
   /** scheme type */
   type: T;
-  /** id of this palette */
+  /** id of this scheme */
   id: string;
   /** human-friendly name to refer to */
   label?: string;

--- a/packages/encodable-color/src/types.ts
+++ b/packages/encodable-color/src/types.ts
@@ -1,15 +1,38 @@
-type BaseColorScheme<T> = {
+export type ColorSchemeType = 'categorical' | 'sequential' | 'diverging';
+
+type BaseColorScheme<T extends ColorSchemeType> = {
+  /** scheme type */
   type: T;
+  /** id of this palette */
   id: string;
+  /** human-friendly name to refer to */
   label?: string;
+  /** more description (if any) */
   description?: string;
+};
+
+export type ColorInterpolator = (t: number) => string;
+
+export type ContinuousScheme<T extends ColorSchemeType> = BaseColorScheme<T> &
+  (
+    | {
+        /** color palette */
+        colors: string[];
+        /** color interpolator function */
+        interpolator?: ColorInterpolator;
+      }
+    | {
+        colors?: string[];
+        interpolator: ColorInterpolator;
+      }
+  );
+
+export type CategoricalScheme = BaseColorScheme<'categorical'> & {
   colors: string[];
 };
 
-export type CategoricalScheme = BaseColorScheme<'categorical'>;
+export type SequentialScheme = ContinuousScheme<'sequential'>;
 
-export type SequentialScheme = BaseColorScheme<'sequential'>;
-
-export type DivergingScheme = BaseColorScheme<'diverging'>;
+export type DivergingScheme = ContinuousScheme<'diverging'>;
 
 export type ColorScheme = CategoricalScheme | SequentialScheme | DivergingScheme;

--- a/packages/encodable-color/test/scheme/ColorSchemeRegistry.test.ts
+++ b/packages/encodable-color/test/scheme/ColorSchemeRegistry.test.ts
@@ -52,7 +52,7 @@ describe('ColorSchemeRegistry', () => {
           type: 'categorical',
           colors,
         });
-        expect(registry.get('abc')?.colors).toEqual(colors);
+        expect(registry.get('abc')?.id).toEqual('abc');
         expect(registry.categorical.get('abc')?.colors).toEqual(colors);
       });
       it('does nothing for invalid scheme', () => {
@@ -75,7 +75,7 @@ describe('ColorSchemeRegistry', () => {
           type: 'categorical',
           colors,
         }));
-        expect(registry.get('abc')?.colors).toEqual(colors);
+        expect(registry.get('abc')?.id).toEqual('abc');
         expect(registry.categorical.get('abc')?.colors).toEqual(colors);
       });
       it('does nothing for invalid scheme', () => {

--- a/packages/encodable-color/test/scheme/ColorSchemeRegistry.test.ts
+++ b/packages/encodable-color/test/scheme/ColorSchemeRegistry.test.ts
@@ -28,6 +28,7 @@ describe('ColorSchemeRegistry', () => {
         expect(registry.get('something')).toBeDefined();
       });
       it('returns undefined otherwise', () => {
+        expect(registry.get()).toBeUndefined();
         expect(registry.get('nothing')).toBeUndefined();
       });
     });
@@ -114,6 +115,7 @@ describe('ColorSchemeRegistry', () => {
           expect(registry.categorical.get('something')).toBeDefined();
         });
         it('returns undefined otherwise', () => {
+          expect(registry.categorical.get()).toBeUndefined();
           expect(registry.categorical.get('nothing')).toBeUndefined();
         });
       });

--- a/packages/encodable-color/test/scheme/wrappers/CategoricalSchemeWrapper.test.ts
+++ b/packages/encodable-color/test/scheme/wrappers/CategoricalSchemeWrapper.test.ts
@@ -1,0 +1,26 @@
+import CategoricalSchemeWrapper from '../../../src/scheme/wrappers/CategoricalSchemeWrapper';
+
+describe('CategoricalSchemeWrapper', () => {
+  const wrapper = new CategoricalSchemeWrapper({
+    type: 'categorical',
+    id: 'test',
+    colors: ['red', 'green', 'blue'],
+    label: 'awesome palette',
+    description: 'something',
+  });
+
+  describe('.getColors()', () => {
+    it('returns colors', () => {
+      expect(wrapper.getColors()).toEqual(['red', 'green', 'blue']);
+      expect(wrapper.getColors(2)).toEqual(['red', 'green']);
+      expect(wrapper.getColors(5)).toEqual(['red', 'green', 'blue', 'red', 'green']);
+      expect(wrapper.getColors(7)).toEqual(['red', 'green', 'blue', 'red', 'green', 'blue', 'red']);
+    });
+  });
+  describe('.createScaleOrdinal()', () => {
+    it('returns scale', () => {
+      const scale = wrapper.createScaleOrdinal();
+      expect(scale('dog')).toEqual('red');
+    });
+  });
+});

--- a/packages/encodable-color/test/scheme/wrappers/DivergingSchemeWrapper.test.ts
+++ b/packages/encodable-color/test/scheme/wrappers/DivergingSchemeWrapper.test.ts
@@ -1,0 +1,33 @@
+import DivergingSchemeWrapper from '../../../src/scheme/wrappers/DivergingSchemeWrapper';
+
+describe('DivergingSchemeWrapper', () => {
+  const wrapper = new DivergingSchemeWrapper({
+    type: 'diverging',
+    id: 'test',
+    colors: ['#00f', '#fff', '#f00'],
+    label: 'blue/white/red',
+    description: 'blue to white to red',
+  });
+
+  describe('.getColors()', () => {
+    it('returns colors', () => {
+      expect(wrapper.getColors()).toEqual(['#00f', '#fff', '#f00']);
+      expect(wrapper.getColors(3)).toEqual(['#00f', '#fff', '#f00']);
+      expect(wrapper.getColors(5)).toEqual([
+        'rgb(0, 0, 255)',
+        'rgb(128, 128, 255)',
+        'rgb(255, 255, 255)',
+        'rgb(255, 128, 128)',
+        'rgb(255, 0, 0)',
+      ]);
+    });
+  });
+  describe('.createScaleLinear()', () => {
+    it('returns scale', () => {
+      const scale = wrapper.createScaleLinear();
+      expect(scale(0)).toEqual('rgb(0, 0, 255)');
+      expect(scale(0.5)).toEqual('rgb(255, 255, 255)');
+      expect(scale(1)).toEqual('rgb(255, 0, 0)');
+    });
+  });
+});

--- a/packages/encodable-color/test/scheme/wrappers/SequentialSchemeWrapper.test.ts
+++ b/packages/encodable-color/test/scheme/wrappers/SequentialSchemeWrapper.test.ts
@@ -1,0 +1,32 @@
+import SequentialSchemeWrapper from '../../../src/scheme/wrappers/SequentialSchemeWrapper';
+
+describe('SequentialSchemeWrapper', () => {
+  const wrapper = new SequentialSchemeWrapper({
+    type: 'sequential',
+    id: 'test',
+    colors: ['#fff', '#f00'],
+    label: 'white to red',
+    description: 'white to red',
+  });
+
+  describe('.getColors()', () => {
+    it('returns colors', () => {
+      expect(wrapper.getColors()).toEqual(['#fff', '#f00']);
+      expect(wrapper.getColors(2)).toEqual(['#fff', '#f00']);
+      expect(wrapper.getColors(5)).toEqual([
+        'rgb(255, 255, 255)',
+        'rgb(255, 191, 191)',
+        'rgb(255, 128, 128)',
+        'rgb(255, 64, 64)',
+        'rgb(255, 0, 0)',
+      ]);
+    });
+  });
+  describe('.createScaleLinear()', () => {
+    it('returns scale', () => {
+      const scale = wrapper.createScaleLinear();
+      expect(scale(0)).toEqual('rgb(255, 255, 255)');
+      expect(scale(1)).toEqual('rgb(255, 0, 0)');
+    });
+  });
+});

--- a/packages/encodable-color/test/scheme/wrappers/SequentialSchemeWrapper.test.ts
+++ b/packages/encodable-color/test/scheme/wrappers/SequentialSchemeWrapper.test.ts
@@ -1,3 +1,4 @@
+import { interpolateBlues } from 'd3-scale-chromatic';
 import SequentialSchemeWrapper from '../../../src/scheme/wrappers/SequentialSchemeWrapper';
 
 describe('SequentialSchemeWrapper', () => {
@@ -7,6 +8,31 @@ describe('SequentialSchemeWrapper', () => {
     colors: ['#fff', '#f00'],
     label: 'white to red',
     description: 'white to red',
+  });
+  const wrapper2 = new SequentialSchemeWrapper({
+    type: 'sequential',
+    id: 'test',
+    interpolator: interpolateBlues,
+    label: 'white to red',
+    description: 'white to red',
+  });
+
+  describe('.colors', () => {
+    it('returns colors from given color array', () => {
+      expect(wrapper.colors).toEqual(['#fff', '#f00']);
+    });
+    it('returns colors from interpolator', () => {
+      expect(wrapper2.colors).toEqual(['rgb(247, 251, 255)', 'rgb(8, 48, 107)']);
+    });
+  });
+
+  describe('.interpolator', () => {
+    it('returns original interpolator', () => {
+      expect(wrapper2.interpolator).toEqual(interpolateBlues);
+    });
+    it('returns interpolator from given color array', () => {
+      expect(wrapper.interpolator(0)).toEqual('rgb(255, 255, 255)');
+    });
   });
 
   describe('.getColors()', () => {

--- a/packages/encodable-color/test/scheme/wrappers/createWrapper.test.ts
+++ b/packages/encodable-color/test/scheme/wrappers/createWrapper.test.ts
@@ -36,4 +36,26 @@ describe('createWrapper()', () => {
       expect(() => createWrapper({ type: 'haha' })).toThrow('Unknown scheme type: haha');
     });
   });
+  describe('creates wrapper only when necessary', () => {
+    it('categorical', () => {
+      const wrapper = createWrapper({
+        type: 'categorical',
+        id: 'test',
+        colors: ['red', 'green', 'blue'],
+      });
+      expect(createWrapper(wrapper)).toBe(wrapper);
+    });
+    it('sequential', () => {
+      const wrapper = createWrapper({ type: 'sequential', id: 'test', colors: ['red', 'white'] });
+      expect(createWrapper(wrapper)).toBe(wrapper);
+    });
+    it('diverging', () => {
+      const wrapper = createWrapper({
+        type: 'diverging',
+        id: 'test',
+        colors: ['red', 'white', 'blue'],
+      });
+      expect(createWrapper(wrapper)).toBe(wrapper);
+    });
+  });
 });

--- a/packages/encodable-color/test/scheme/wrappers/createWrapper.test.ts
+++ b/packages/encodable-color/test/scheme/wrappers/createWrapper.test.ts
@@ -1,0 +1,39 @@
+import createWrapper from '../../../src/scheme/wrappers/createWrapper';
+
+describe('createWrapper()', () => {
+  it('returns wrapper with getters', () => {
+    const wrapper = createWrapper({
+      type: 'categorical',
+      id: 'test',
+      colors: ['red', 'green', 'blue'],
+      label: 'awesome palette',
+      description: 'something',
+    });
+
+    expect(wrapper.id).toEqual('test');
+    expect(wrapper.type).toEqual('categorical');
+    expect(wrapper.label).toEqual('awesome palette');
+    expect(wrapper.description).toEqual('something');
+  });
+  describe('support all scheme types', () => {
+    it('categorical', () => {
+      expect(
+        createWrapper({ type: 'categorical', id: 'test', colors: ['red', 'green', 'blue'] }),
+      ).toBeDefined();
+    });
+    it('sequential', () => {
+      expect(
+        createWrapper({ type: 'sequential', id: 'test', colors: ['red', 'white'] }),
+      ).toBeDefined();
+    });
+    it('diverging', () => {
+      expect(
+        createWrapper({ type: 'diverging', id: 'test', colors: ['red', 'white', 'blue'] }),
+      ).toBeDefined();
+    });
+    it('otherwise', () => {
+      // @ts-ignore
+      expect(() => createWrapper({ type: 'haha' })).toThrow('Unknown scheme type: haha');
+    });
+  });
+});

--- a/packages/encodable-color/test/scheme/wrappers/wrapColorScheme.test.ts
+++ b/packages/encodable-color/test/scheme/wrappers/wrapColorScheme.test.ts
@@ -1,8 +1,8 @@
-import createWrapper from '../../../src/scheme/wrappers/createWrapper';
+import wrapColorScheme from '../../../src/scheme/wrappers/wrapColorScheme';
 
-describe('createWrapper()', () => {
+describe('wrapColorScheme()', () => {
   it('returns wrapper with getters', () => {
-    const wrapper = createWrapper({
+    const wrapper = wrapColorScheme({
       type: 'categorical',
       id: 'test',
       colors: ['red', 'green', 'blue'],
@@ -18,44 +18,44 @@ describe('createWrapper()', () => {
   describe('support all scheme types', () => {
     it('categorical', () => {
       expect(
-        createWrapper({ type: 'categorical', id: 'test', colors: ['red', 'green', 'blue'] }),
+        wrapColorScheme({ type: 'categorical', id: 'test', colors: ['red', 'green', 'blue'] }),
       ).toBeDefined();
     });
     it('sequential', () => {
       expect(
-        createWrapper({ type: 'sequential', id: 'test', colors: ['red', 'white'] }),
+        wrapColorScheme({ type: 'sequential', id: 'test', colors: ['red', 'white'] }),
       ).toBeDefined();
     });
     it('diverging', () => {
       expect(
-        createWrapper({ type: 'diverging', id: 'test', colors: ['red', 'white', 'blue'] }),
+        wrapColorScheme({ type: 'diverging', id: 'test', colors: ['red', 'white', 'blue'] }),
       ).toBeDefined();
     });
     it('otherwise', () => {
       // @ts-ignore
-      expect(() => createWrapper({ type: 'haha' })).toThrow('Unknown scheme type: haha');
+      expect(() => wrapColorScheme({ type: 'haha' })).toThrow('Unknown scheme type: haha');
     });
   });
   describe('creates wrapper only when necessary', () => {
     it('categorical', () => {
-      const wrapper = createWrapper({
+      const wrapper = wrapColorScheme({
         type: 'categorical',
         id: 'test',
         colors: ['red', 'green', 'blue'],
       });
-      expect(createWrapper(wrapper)).toBe(wrapper);
+      expect(wrapColorScheme(wrapper)).toBe(wrapper);
     });
     it('sequential', () => {
-      const wrapper = createWrapper({ type: 'sequential', id: 'test', colors: ['red', 'white'] });
-      expect(createWrapper(wrapper)).toBe(wrapper);
+      const wrapper = wrapColorScheme({ type: 'sequential', id: 'test', colors: ['red', 'white'] });
+      expect(wrapColorScheme(wrapper)).toBe(wrapper);
     });
     it('diverging', () => {
-      const wrapper = createWrapper({
+      const wrapper = wrapColorScheme({
         type: 'diverging',
         id: 'test',
         colors: ['red', 'white', 'blue'],
       });
-      expect(createWrapper(wrapper)).toBe(wrapper);
+      expect(wrapColorScheme(wrapper)).toBe(wrapper);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2729,6 +2729,11 @@
   dependencies:
     "@types/d3-color" "*"
 
+"@types/d3-scale-chromatic@^1.2.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz#315367557d51b823bec848614fac095325613fc3"
+  integrity sha512-9/D7cOBKdZdTCPc6re0HeSUFBM0aFzdNdmYggUWT9SRRiYSOa6Ys2xdTwHKgc1WS3gGfwTMatBOdWCS863REsg==
+
 "@types/d3-scale@^2.1.1", "@types/d3-scale@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-2.2.0.tgz#e5987a2857365823eb26ed5eb21bc566c4dcf1c0"
@@ -4690,12 +4695,20 @@ d3-format@1, d3-format@^1.3.2, d3-format@^1.4.4:
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.4.tgz#356925f28d0fd7c7983bfad593726fce46844030"
   integrity sha512-TWks25e7t8/cqctxCmxpUuzZN11QxIA7YrMbram94zMQ0PXjE4LVIMe/f6a4+xxL8HQ3OsAFULOINQi1pE62Aw==
 
-d3-interpolate@^1.2.0, d3-interpolate@^1.3.2, d3-interpolate@^1.4.0:
+d3-interpolate@1, d3-interpolate@^1.2.0, d3-interpolate@^1.3.2, d3-interpolate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
   integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
   dependencies:
     d3-color "1"
+
+d3-scale-chromatic@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz#54e333fc78212f439b14641fb55801dd81135a98"
+  integrity sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==
+  dependencies:
+    d3-color "1"
+    d3-interpolate "1"
 
 d3-scale@^3.0.0, d3-scale@^3.0.1, d3-scale@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
🏆 Enhancements

Add wrapper for color schemes to help creating scales and getting colors. 
Also make the scheme support interpolator for sequential and diverging scales. 
These scales can take just interpolator without array of colors. Similar to schemes in `d3-scale-chromatic` that has `d3InterpolateXXX` and `d3SchemeXXX`
