### PR TITLE
feat(color): add d3 schemes and more flexible color scheme handling

### DIFF
--- a/packages/encodable-color/src/scale/ColorNamespace.ts
+++ b/packages/encodable-color/src/scale/ColorNamespace.ts
@@ -79,7 +79,7 @@ export default class ColorNamespace {
     if (typeof this.state.scales[schemeName] === 'undefined') {
       // create scale
       const scale = new ScaleCategoricalColor(
-        getCategoricalScheme(schemeName)?.colors ?? [],
+        getCategoricalScheme(schemeName)?.colors.slice() ?? [],
         this.state.manualColors,
       );
       // add state to lookup

--- a/packages/encodable-color/src/scheme/ChildRegistry.ts
+++ b/packages/encodable-color/src/scheme/ChildRegistry.ts
@@ -34,7 +34,13 @@ export default class ChildRegistry<
       : undefined;
   }
 
-  register(value: Scheme) {
+  register(value: Scheme | Scheme[]) {
+    if (Array.isArray(value)) {
+      value.forEach(v => {
+        this.registerValue(v.id, v);
+      });
+      return this;
+    }
     return this.registerValue(value.id, value);
   }
 

--- a/packages/encodable-color/src/scheme/ColorSchemeRegistry.ts
+++ b/packages/encodable-color/src/scheme/ColorSchemeRegistry.ts
@@ -76,7 +76,13 @@ export default class ColorSchemeRegistry extends SyncRegistry<ColorScheme> {
     return this;
   }
 
-  register(value: ColorScheme) {
+  register(value: ColorScheme | ColorScheme[]) {
+    if (Array.isArray(value)) {
+      value.forEach(v => {
+        this.registerValue(v.id, v);
+      });
+      return this;
+    }
     return this.registerValue(value.id, value);
   }
 

--- a/packages/encodable-color/src/scheme/index.ts
+++ b/packages/encodable-color/src/scheme/index.ts
@@ -1,6 +1,5 @@
 import { makeSingleton } from '@encodable/registry';
 import ColorSchemeRegistry from './ColorSchemeRegistry';
-import wrapColorScheme from './wrappers/wrapColorScheme';
 
 export const getColorSchemeRegistry = makeSingleton(
   () =>
@@ -25,4 +24,6 @@ export function getDivergingScheme(key?: string) {
   return getColorSchemeRegistry().diverging.get(key);
 }
 
-export { ColorSchemeRegistry, wrapColorScheme };
+export { ColorSchemeRegistry };
+export { default as wrapColorScheme } from './wrappers/wrapColorScheme';
+export * from './presets/d3Schemes';

--- a/packages/encodable-color/src/scheme/index.ts
+++ b/packages/encodable-color/src/scheme/index.ts
@@ -1,5 +1,6 @@
 import { makeSingleton } from '@encodable/registry';
 import ColorSchemeRegistry from './ColorSchemeRegistry';
+import wrapColorScheme from './wrappers/wrapColorScheme';
 
 export const getColorSchemeRegistry = makeSingleton(
   () =>
@@ -24,4 +25,4 @@ export function getDivergingScheme(key?: string) {
   return getColorSchemeRegistry().diverging.get(key);
 }
 
-export { ColorSchemeRegistry };
+export { ColorSchemeRegistry, wrapColorScheme };

--- a/packages/encodable-color/src/scheme/presets/d3Schemes.ts
+++ b/packages/encodable-color/src/scheme/presets/d3Schemes.ts
@@ -1,0 +1,386 @@
+import {
+  schemeCategory10,
+  schemeAccent,
+  schemeDark2,
+  schemePaired,
+  schemePastel1,
+  schemePastel2,
+  schemeSet1,
+  schemeSet2,
+  schemeSet3,
+  schemeTableau10,
+  interpolateBrBG,
+  schemeBrBG,
+  interpolatePRGn,
+  schemePRGn,
+  interpolatePiYG,
+  schemePiYG,
+  interpolatePuOr,
+  schemePuOr,
+  interpolateRdBu,
+  schemeRdBu,
+  interpolateRdGy,
+  schemeRdGy,
+  interpolateRdYlBu,
+  schemeRdYlBu,
+  interpolateRdYlGn,
+  schemeRdYlGn,
+  interpolateSpectral,
+  schemeSpectral,
+  interpolateBlues,
+  schemeBlues,
+  interpolateGreens,
+  schemeGreens,
+  interpolateGreys,
+  schemeGreys,
+  interpolateOranges,
+  schemeOranges,
+  interpolatePurples,
+  schemePurples,
+  interpolateReds,
+  schemeReds,
+  interpolateTurbo,
+  interpolateViridis,
+  interpolateInferno,
+  interpolateMagma,
+  interpolatePlasma,
+  interpolateCividis,
+  interpolateWarm,
+  interpolateCool,
+  interpolateCubehelixDefault,
+  interpolateBuGn,
+  schemeBuGn,
+  interpolateBuPu,
+  schemeBuPu,
+  interpolateGnBu,
+  schemeGnBu,
+  interpolateOrRd,
+  schemeOrRd,
+  interpolatePuBuGn,
+  schemePuBuGn,
+  interpolatePuBu,
+  schemePuBu,
+  interpolatePuRd,
+  schemePuRd,
+  interpolateRdPu,
+  schemeRdPu,
+  interpolateYlGnBu,
+  schemeYlGnBu,
+  interpolateYlGn,
+  schemeYlGn,
+  interpolateYlOrBr,
+  schemeYlOrBr,
+  interpolateYlOrRd,
+  schemeYlOrRd,
+  interpolateRainbow,
+  interpolateSinebow,
+} from 'd3-scale-chromatic';
+import type {
+  ColorScheme,
+  CategoricalScheme,
+  SequentialScheme,
+  DivergingScheme,
+} from '../../types';
+
+const d3CategoricalSchemes: CategoricalScheme[] = [
+  {
+    type: 'categorical',
+    id: 'd3.category10',
+    colors: schemeCategory10,
+  },
+  {
+    type: 'categorical',
+    id: 'd3.accent',
+    colors: schemeAccent,
+  },
+  {
+    type: 'categorical',
+    id: 'd3.dark2',
+    colors: schemeDark2,
+  },
+  {
+    type: 'categorical',
+    id: 'd3.paired',
+    colors: schemePaired,
+  },
+  {
+    type: 'categorical',
+    id: 'd3.pastel1',
+    colors: schemePastel1,
+  },
+  {
+    type: 'categorical',
+    id: 'd3.pastel2',
+    colors: schemePastel2,
+  },
+  {
+    type: 'categorical',
+    id: 'd3.set1',
+    colors: schemeSet1,
+  },
+  {
+    type: 'categorical',
+    id: 'd3.set2',
+    colors: schemeSet2,
+  },
+  {
+    type: 'categorical',
+    id: 'd3.set3',
+    colors: schemeSet3,
+  },
+  {
+    type: 'categorical',
+    id: 'd3.tableau10',
+    colors: schemeTableau10,
+  },
+];
+
+const d3DivergingSchemes: DivergingScheme[] = [
+  {
+    type: 'diverging',
+    id: 'd3.BrBg',
+    interpolator: interpolateBrBG,
+    colors: schemeBrBG,
+  },
+  {
+    type: 'diverging',
+    id: 'd3.PRGn',
+    interpolator: interpolatePRGn,
+    colors: schemePRGn,
+  },
+  {
+    type: 'diverging',
+    id: 'd3.PiYG',
+    interpolator: interpolatePiYG,
+    colors: schemePiYG,
+  },
+  {
+    type: 'diverging',
+    id: 'd3.PuOr',
+    interpolator: interpolatePuOr,
+    colors: schemePuOr,
+  },
+  {
+    type: 'diverging',
+    id: 'd3.RdBu',
+    interpolator: interpolateRdBu,
+    colors: schemeRdBu,
+  },
+  {
+    type: 'diverging',
+    id: 'd3.RdGy',
+    interpolator: interpolateRdGy,
+    colors: schemeRdGy,
+  },
+  {
+    type: 'diverging',
+    id: 'd3.RdYlBu',
+    interpolator: interpolateRdYlBu,
+    colors: schemeRdYlBu,
+  },
+  {
+    type: 'diverging',
+    id: 'd3.RdYlGn',
+    interpolator: interpolateRdYlGn,
+    colors: schemeRdYlGn,
+  },
+  {
+    type: 'diverging',
+    id: 'd3.spectral',
+    interpolator: interpolateSpectral,
+    colors: schemeSpectral,
+  },
+];
+
+const d3SingleHueSchemes: SequentialScheme[] = [
+  {
+    type: 'sequential',
+    id: 'd3.blues',
+    interpolator: interpolateBlues,
+    colors: schemeBlues,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.greens',
+    interpolator: interpolateGreens,
+    colors: schemeGreens,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.greys',
+    interpolator: interpolateGreys,
+    colors: schemeGreys,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.oranges',
+    interpolator: interpolateOranges,
+    colors: schemeOranges,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.purples',
+    interpolator: interpolatePurples,
+    colors: schemePurples,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.reds',
+    interpolator: interpolateReds,
+    colors: schemeReds,
+  },
+];
+
+const d3MultiHueSchemes: SequentialScheme[] = [
+  {
+    type: 'sequential',
+    id: 'd3.turbo',
+    interpolator: interpolateTurbo,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.viridis',
+    interpolator: interpolateViridis,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.inferno',
+    interpolator: interpolateInferno,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.magma',
+    interpolator: interpolateMagma,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.plasma',
+    interpolator: interpolatePlasma,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.cividis',
+    interpolator: interpolateCividis,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.warm',
+    interpolator: interpolateWarm,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.cool',
+    interpolator: interpolateCool,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.cubehelixDefault',
+    interpolator: interpolateCubehelixDefault,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.cubehelixDefault',
+    interpolator: interpolateCubehelixDefault,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.BuGn',
+    interpolator: interpolateBuGn,
+    colors: schemeBuGn,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.BuPu',
+    interpolator: interpolateBuPu,
+    colors: schemeBuPu,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.GnBu',
+    interpolator: interpolateGnBu,
+    colors: schemeGnBu,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.OrRd',
+    interpolator: interpolateOrRd,
+    colors: schemeOrRd,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.PuBuGn',
+    interpolator: interpolatePuBuGn,
+    colors: schemePuBuGn,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.PuBu',
+    interpolator: interpolatePuBu,
+    colors: schemePuBu,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.PuRd',
+    interpolator: interpolatePuRd,
+    colors: schemePuRd,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.RdPu',
+    interpolator: interpolateRdPu,
+    colors: schemeRdPu,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.YlGnBu',
+    interpolator: interpolateYlGnBu,
+    colors: schemeYlGnBu,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.YlGn',
+    interpolator: interpolateYlGn,
+    colors: schemeYlGn,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.YlOrBr',
+    interpolator: interpolateYlOrBr,
+    colors: schemeYlOrBr,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.YlOrRd',
+    interpolator: interpolateYlOrRd,
+    colors: schemeYlOrRd,
+  },
+];
+
+const d3CyclicalSchemes: SequentialScheme[] = [
+  {
+    type: 'sequential',
+    id: 'd3.rainbow',
+    interpolator: interpolateRainbow,
+  },
+  {
+    type: 'sequential',
+    id: 'd3.sinebow',
+    interpolator: interpolateSinebow,
+  },
+];
+
+const d3SequentialSchemes = d3SingleHueSchemes.concat(d3MultiHueSchemes).concat(d3CyclicalSchemes);
+
+const d3Schemes = (d3CategoricalSchemes as ColorScheme[])
+  .concat(d3DivergingSchemes)
+  .concat(d3SequentialSchemes);
+
+export {
+  d3Schemes,
+  d3CategoricalSchemes,
+  d3DivergingSchemes,
+  d3SequentialSchemes,
+  d3SingleHueSchemes,
+  d3MultiHueSchemes,
+  d3CyclicalSchemes,
+};

--- a/packages/encodable-color/src/scheme/presets/d3Schemes.ts
+++ b/packages/encodable-color/src/scheme/presets/d3Schemes.ts
@@ -138,7 +138,13 @@ const d3CategoricalSchemes: CategoricalScheme[] = [
 const d3DivergingSchemes: DivergingScheme[] = [
   {
     type: 'diverging',
-    id: 'd3.BrBg',
+    id: 'd3.RdBu',
+    interpolator: interpolateRdBu,
+    colors: schemeRdBu,
+  },
+  {
+    type: 'diverging',
+    id: 'd3.BrBG',
     interpolator: interpolateBrBG,
     colors: schemeBrBG,
   },
@@ -159,12 +165,6 @@ const d3DivergingSchemes: DivergingScheme[] = [
     id: 'd3.PuOr',
     interpolator: interpolatePuOr,
     colors: schemePuOr,
-  },
-  {
-    type: 'diverging',
-    id: 'd3.RdBu',
-    interpolator: interpolateRdBu,
-    colors: schemeRdBu,
   },
   {
     type: 'diverging',

--- a/packages/encodable-color/src/types.ts
+++ b/packages/encodable-color/src/types.ts
@@ -17,18 +17,18 @@ export type ContinuousScheme<T extends ColorSchemeType> = BaseColorScheme<T> &
   (
     | {
         /** color palette */
-        colors: string[];
+        colors: readonly string[] | readonly (readonly string[])[];
         /** color interpolator function */
         interpolator?: ColorInterpolator;
       }
     | {
-        colors?: string[];
+        colors?: readonly string[] | readonly (readonly string[])[];
         interpolator: ColorInterpolator;
       }
   );
 
 export type CategoricalScheme = BaseColorScheme<'categorical'> & {
-  colors: string[];
+  colors: readonly string[];
 };
 
 export type SequentialScheme = ContinuousScheme<'sequential'>;

--- a/packages/encodable-color/test/scheme/ColorSchemeRegistry.test.ts
+++ b/packages/encodable-color/test/scheme/ColorSchemeRegistry.test.ts
@@ -56,6 +56,24 @@ describe('ColorSchemeRegistry', () => {
         expect(registry.get('abc')?.id).toEqual('abc');
         expect(registry.categorical.get('abc')?.colors).toEqual(colors);
       });
+      it('registers multiple schemes', () => {
+        registry.register([
+          {
+            id: 'abc',
+            type: 'categorical',
+            colors: ['red', 'green', 'blue'],
+          },
+          {
+            id: 'def',
+            type: 'categorical',
+            colors: ['yellow', 'green', 'purple'],
+          },
+        ]);
+        expect(registry.get('abc')?.id).toEqual('abc');
+        expect(registry.get('def')?.id).toEqual('def');
+        expect(registry.categorical.get('abc')?.id).toEqual('abc');
+        expect(registry.categorical.get('def')?.id).toEqual('def');
+      });
     });
     describe('.registerValue()', () => {
       it('registers to both registry and child registry', () => {
@@ -167,7 +185,7 @@ describe('ColorSchemeRegistry', () => {
         });
       });
       describe('.register()', () => {
-        it('registers value', () => {
+        it('registers scheme', () => {
           const colors = ['red', 'green', 'blue'];
           registry.categorical.register({
             id: 'abc',
@@ -176,6 +194,24 @@ describe('ColorSchemeRegistry', () => {
           });
           expect(registry.has('abc')).toBeTruthy();
           expect(registry.categorical.has('abc')).toBeTruthy();
+        });
+        it('registers multiple schemes', () => {
+          registry.categorical.register([
+            {
+              id: 'abc',
+              type: 'categorical',
+              colors: ['red', 'green', 'blue'],
+            },
+            {
+              id: 'def',
+              type: 'categorical',
+              colors: ['yellow', 'green', 'purple'],
+            },
+          ]);
+          expect(registry.get('abc')?.id).toEqual('abc');
+          expect(registry.get('def')?.id).toEqual('def');
+          expect(registry.categorical.get('abc')?.id).toEqual('abc');
+          expect(registry.categorical.get('def')?.id).toEqual('def');
         });
       });
       describe('.registerValue()', () => {

--- a/packages/encodable-color/test/scheme/wrappers/SequentialSchemeWrapper.test.ts
+++ b/packages/encodable-color/test/scheme/wrappers/SequentialSchemeWrapper.test.ts
@@ -1,4 +1,4 @@
-import { interpolateBlues } from 'd3-scale-chromatic';
+import { interpolateBlues, schemeBlues } from 'd3-scale-chromatic';
 import SequentialSchemeWrapper from '../../../src/scheme/wrappers/SequentialSchemeWrapper';
 
 describe('SequentialSchemeWrapper', () => {
@@ -33,6 +33,15 @@ describe('SequentialSchemeWrapper', () => {
     it('returns interpolator from given color array', () => {
       expect(wrapper.interpolator(0)).toEqual('rgb(255, 255, 255)');
     });
+    it('works when given colors is an array of arrays', () => {
+      const wrapper3 = new SequentialSchemeWrapper({
+        type: 'sequential',
+        id: 'test',
+        colors: schemeBlues,
+      });
+      expect(wrapper3.interpolator(0)).toEqual('rgb(247, 251, 255)');
+      expect(wrapper3.interpolator(1)).toEqual('rgb(8, 48, 107)');
+    });
   });
 
   describe('.getColors()', () => {
@@ -46,6 +55,21 @@ describe('SequentialSchemeWrapper', () => {
         'rgb(255, 64, 64)',
         'rgb(255, 0, 0)',
       ]);
+    });
+    it('works when given colors is an array of arrays', () => {
+      const wrapper3 = new SequentialSchemeWrapper({
+        type: 'sequential',
+        id: 'test',
+        colors: schemeBlues,
+      });
+      expect(wrapper3.getColors(2)).toEqual(['rgb(247, 251, 255)', 'rgb(8, 48, 107)']);
+      expect(wrapper3.getColors(3)).toEqual(schemeBlues[3]);
+      expect(wrapper3.getColors(4)).toEqual(schemeBlues[4]);
+      expect(wrapper3.getColors(5)).toEqual(schemeBlues[5]);
+      expect(wrapper3.getColors(6)).toEqual(schemeBlues[6]);
+      expect(wrapper3.getColors(7)).toEqual(schemeBlues[7]);
+      expect(wrapper3.getColors(8)).toEqual(schemeBlues[8]);
+      expect(wrapper3.getColors(9)).toEqual(schemeBlues[9]);
     });
   });
   describe('.createScaleLinear()', () => {


### PR DESCRIPTION
🏆 Enhancements

* can register multiple schemes at once via `ColorSchemeRegistry.register()`

* support array of array for `colors` fields in continuous schemes to support D3 schemes. 

> Each discrete scheme, such as d3.schemeBrBG, is represented as an array of arrays of hexadecimal color strings. The kth element of this array contains the color scheme of size k; for example, d3.schemeBrBG[9] contains an array of nine strings representing the nine colors of the brown-blue-green diverging color scheme. Diverging color schemes support a size k ranging from 3 to 11.

From https://github.com/d3/d3-scale-chromatic#interpolateBrBG

* define schemes based on d3 schemes 

```ts
export {
  d3Schemes,
  d3CategoricalSchemes,
  d3DivergingSchemes,
  d3SequentialSchemes,
  d3SingleHueSchemes,
  d3MultiHueSchemes,
  d3CyclicalSchemes,
};
```

