### PR TITLE
feat(color): include d3 schemes by default

### DIFF
--- a/packages/encodable-color/src/scheme/ChildRegistry.ts
+++ b/packages/encodable-color/src/scheme/ChildRegistry.ts
@@ -27,38 +27,38 @@ export default class ChildRegistry<
     this.parent = parent;
   }
 
-  get(key?: string): Wrapper | undefined {
-    const targetKey = key ?? this.getDefaultKey();
+  get(schemeId?: string): Wrapper | undefined {
+    const targetKey = schemeId ?? this.getDefaultKey();
     return typeof targetKey !== 'undefined' && this.has(targetKey)
-      ? (this.parent.get(key)! as Wrapper)
+      ? (this.parent.get(schemeId)! as Wrapper)
       : undefined;
   }
 
-  register(value: Scheme | Scheme[]) {
-    if (Array.isArray(value)) {
-      value.forEach(v => {
+  register(scheme: Scheme | Scheme[]) {
+    if (Array.isArray(scheme)) {
+      scheme.forEach(v => {
         this.registerValue(v.id, v);
       });
       return this;
     }
-    return this.registerValue(value.id, value);
+    return this.registerValue(scheme.id, scheme);
   }
 
-  _registerValue(key: string, value: Scheme) {
-    return super.registerValue(key, value);
+  _registerValue(schemeId: string, scheme: Scheme) {
+    return super.registerValue(schemeId, scheme);
   }
 
-  registerValue(key: string, value: Scheme) {
-    this.parent.registerValue(key, value);
+  registerValue(schemeId: string, scheme: Scheme) {
+    this.parent.registerValue(schemeId, scheme);
     return this;
   }
 
-  _registerLoader(key: string, loader: () => Scheme) {
-    return super.registerLoader(key, loader);
+  _registerLoader(schemeId: string, loader: () => Scheme) {
+    return super.registerLoader(schemeId, loader);
   }
 
-  registerLoader(key: string, loader: () => Scheme) {
-    this.parent.registerLoader(key, loader);
+  registerLoader(schemeId: string, loader: () => Scheme) {
+    this.parent.registerLoader(schemeId, loader);
     return this;
   }
 
@@ -71,12 +71,12 @@ export default class ChildRegistry<
     return super.clear();
   }
 
-  remove(key: string) {
-    this.parent.remove(key);
+  remove(schemeId: string) {
+    this.parent.remove(schemeId);
     return this;
   }
 
-  _remove(key: string) {
-    return super.remove(key);
+  _remove(schemeId: string) {
+    return super.remove(schemeId);
   }
 }

--- a/packages/encodable-color/src/scheme/ColorSchemeRegistry.ts
+++ b/packages/encodable-color/src/scheme/ColorSchemeRegistry.ts
@@ -36,8 +36,8 @@ export default class ColorSchemeRegistry extends SyncRegistry<ColorScheme> {
     this.wrappers = new SyncRegistry<ColorSchemeWrapper>();
   }
 
-  get(key?: string): ColorSchemeWrapper | undefined {
-    const targetKey = key ?? this.getDefaultKey();
+  get(schemeId?: string): ColorSchemeWrapper | undefined {
+    const targetKey = schemeId ?? this.getDefaultKey();
 
     if (typeof targetKey === 'undefined') {
       return undefined;
@@ -50,7 +50,7 @@ export default class ColorSchemeRegistry extends SyncRegistry<ColorScheme> {
     }
 
     if (this.wrappers.has(targetKey)) {
-      return this.wrappers.get(key);
+      return this.wrappers.get(schemeId);
     }
 
     const wrapper = wrapColorScheme(value);
@@ -67,38 +67,38 @@ export default class ColorSchemeRegistry extends SyncRegistry<ColorScheme> {
     return this;
   }
 
-  remove(key: string) {
-    super.remove(key);
-    this.categorical._remove(key);
-    this.sequential._remove(key);
-    this.diverging._remove(key);
+  remove(schemeId: string) {
+    super.remove(schemeId);
+    this.categorical._remove(schemeId);
+    this.sequential._remove(schemeId);
+    this.diverging._remove(schemeId);
 
     return this;
   }
 
-  register(value: ColorScheme | ColorScheme[]) {
-    if (Array.isArray(value)) {
-      value.forEach(v => {
+  register(scheme: ColorScheme | ColorScheme[]) {
+    if (Array.isArray(scheme)) {
+      scheme.forEach(v => {
         this.registerValue(v.id, v);
       });
       return this;
     }
-    return this.registerValue(value.id, value);
+    return this.registerValue(scheme.id, scheme);
   }
 
-  registerValue(key: string, value: ColorScheme) {
-    switch (value.type) {
+  registerValue(schemeId: string, scheme: ColorScheme) {
+    switch (scheme.type) {
       case 'categorical':
-        super.registerValue(key, value);
-        this.categorical._registerValue(key, value);
+        super.registerValue(schemeId, scheme);
+        this.categorical._registerValue(schemeId, scheme);
         break;
       case 'sequential':
-        super.registerValue(key, value);
-        this.sequential._registerValue(key, value);
+        super.registerValue(schemeId, scheme);
+        this.sequential._registerValue(schemeId, scheme);
         break;
       case 'diverging':
-        super.registerValue(key, value);
-        this.diverging._registerValue(key, value);
+        super.registerValue(schemeId, scheme);
+        this.diverging._registerValue(schemeId, scheme);
         break;
       default:
     }
@@ -106,21 +106,21 @@ export default class ColorSchemeRegistry extends SyncRegistry<ColorScheme> {
     return this;
   }
 
-  registerLoader(key: string, loader: () => ColorScheme) {
+  registerLoader(schemeId: string, loader: () => ColorScheme) {
     const value = loader();
 
     switch (value.type) {
       case 'categorical':
-        super.registerLoader(key, loader);
-        this.categorical._registerLoader(key, loader as () => CategoricalScheme);
+        super.registerLoader(schemeId, loader);
+        this.categorical._registerLoader(schemeId, loader as () => CategoricalScheme);
         break;
       case 'sequential':
-        super.registerLoader(key, loader);
-        this.sequential._registerLoader(key, loader as () => SequentialScheme);
+        super.registerLoader(schemeId, loader);
+        this.sequential._registerLoader(schemeId, loader as () => SequentialScheme);
         break;
       case 'diverging':
-        super.registerLoader(key, loader);
-        this.diverging._registerLoader(key, loader as () => DivergingScheme);
+        super.registerLoader(schemeId, loader);
+        this.diverging._registerLoader(schemeId, loader as () => DivergingScheme);
         break;
       default:
     }

--- a/packages/encodable-color/src/scheme/index.ts
+++ b/packages/encodable-color/src/scheme/index.ts
@@ -1,27 +1,27 @@
 import { makeSingleton } from '@encodable/registry';
 import ColorSchemeRegistry from './ColorSchemeRegistry';
+import { d3Schemes } from './presets/d3Schemes';
 
-export const getColorSchemeRegistry = makeSingleton(
-  () =>
-    new ColorSchemeRegistry({
-      globalId: '@encodable/color:ColorSchemeRegistry',
-    }),
+export const getColorSchemeRegistry = makeSingleton(() =>
+  new ColorSchemeRegistry({
+    globalId: '@encodable/color:ColorSchemeRegistry',
+  }).register(d3Schemes),
 );
 
-export function getColorScheme(key?: string) {
-  return getColorSchemeRegistry().get(key);
+export function getColorScheme(schemeId?: string) {
+  return getColorSchemeRegistry().get(schemeId);
 }
 
-export function getCategoricalScheme(key?: string) {
-  return getColorSchemeRegistry().categorical.get(key);
+export function getCategoricalScheme(schemeId?: string) {
+  return getColorSchemeRegistry().categorical.get(schemeId);
 }
 
-export function getSequentialScheme(key?: string) {
-  return getColorSchemeRegistry().sequential.get(key);
+export function getSequentialScheme(schemeId?: string) {
+  return getColorSchemeRegistry().sequential.get(schemeId);
 }
 
-export function getDivergingScheme(key?: string) {
-  return getColorSchemeRegistry().diverging.get(key);
+export function getDivergingScheme(schemeId?: string) {
+  return getColorSchemeRegistry().diverging.get(schemeId);
 }
 
 export { ColorSchemeRegistry };

--- a/packages/encodable-color/src/types.ts
+++ b/packages/encodable-color/src/types.ts
@@ -22,12 +22,15 @@ export type ContinuousScheme<T extends ColorSchemeType> = BaseColorScheme<T> &
         interpolator?: ColorInterpolator;
       }
     | {
+        /** color palette */
         colors?: readonly string[] | readonly (readonly string[])[];
+        /** color interpolator function */
         interpolator: ColorInterpolator;
       }
   );
 
 export type CategoricalScheme = BaseColorScheme<'categorical'> & {
+  /** color palette */
   colors: readonly string[];
 };
 


### PR DESCRIPTION
🏆 Enhancements

* include d3 schemes by default so `getColorSchemeRegistry()` is ready to use straight out-of-the-box.

🏠 Internal

* rename parameter names: `key` to `schemeId` and `value` to `scheme` where applicable.